### PR TITLE
Add cube movement and particle tests

### DIFF
--- a/TestUnity/Assets/Scripts/RuntimeScripts.asmdef
+++ b/TestUnity/Assets/Scripts/RuntimeScripts.asmdef
@@ -1,0 +1,3 @@
+{
+  "name": "RuntimeScripts"
+}

--- a/TestUnity/Assets/Scripts/RuntimeScripts.asmdef.meta
+++ b/TestUnity/Assets/Scripts/RuntimeScripts.asmdef.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8b27b9ee53d3493194c4d46c5b2ceb5e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/TestUnity/Assets/Scripts/TestScript.cs
+++ b/TestUnity/Assets/Scripts/TestScript.cs
@@ -2,11 +2,34 @@ using UnityEngine;
 
 public class TestScript : MonoBehaviour
 {
+    public GameObject cube;
+    public ParticleSystem particle;
+
     void Start()
     {
-        // Create a cube and move it up slightly
-        GameObject cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
+        // Create a cube and position it slightly above ground
+        cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
         cube.transform.position = new Vector3(0, 1, 0);
-        Debug.Log("Cube created and positioned");
+
+        // Add a simple particle system to the cube
+        particle = cube.AddComponent<ParticleSystem>();
+        particle.Stop(true, ParticleSystemStopBehavior.StopEmittingAndClear);
+        var main = particle.main;
+        main.duration = 1f;
+        main.startLifetime = 0.5f;
+        main.loop = false;
+        particle.Play();
+
+        Debug.Log("Cube created and particle started");
+    }
+
+    void Update()
+    {
+        if (cube != null)
+        {
+            // Move cube left and right with a period of 2 seconds
+            float x = Mathf.Sin(Time.time * Mathf.PI);
+            cube.transform.position = new Vector3(x, 1, 0);
+        }
     }
 }

--- a/TestUnity/Assets/Tests.meta
+++ b/TestUnity/Assets/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d660c4199cf5c23f881f92e9f36ef7e8
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Tests/PlayMode.meta
+++ b/TestUnity/Assets/Tests/PlayMode.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3f6e1ff73dc22beecb526cf35e279fe4
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Tests/PlayMode/CubePlayModeTests.cs
+++ b/TestUnity/Assets/Tests/PlayMode/CubePlayModeTests.cs
@@ -1,0 +1,53 @@
+#if UNITY_INCLUDE_TESTS
+using UnityEngine;
+using UnityEngine.TestTools;
+using NUnit.Framework;
+using System.Collections;
+
+public class CubePlayModeTests
+{
+    private GameObject go;
+    private TestScript script;
+
+    [UnitySetUp]
+    public IEnumerator SetUp()
+    {
+        go = new GameObject("TestObject");
+        script = go.AddComponent<TestScript>();
+        yield return null; // wait a frame for Start()
+    }
+
+    [UnityTearDown]
+    public IEnumerator TearDown()
+    {
+        Object.Destroy(go);
+        yield return null;
+    }
+
+    [UnityTest]
+    public IEnumerator CubeMovesLeftRightAndParticlePlays()
+    {
+        Assert.IsNotNull(script.cube);
+        Assert.IsNotNull(script.particle);
+
+        float startX = script.cube.transform.position.x;
+        Assert.IsTrue(script.particle.isPlaying);
+
+        yield return new WaitForSeconds(0.5f);
+        float rightX = script.cube.transform.position.x;
+        Assert.Greater(rightX, startX);
+
+        yield return new WaitForSeconds(1.0f);
+        float leftX = script.cube.transform.position.x;
+        Assert.Less(leftX, startX);
+
+        yield return new WaitForSeconds(0.5f);
+        float endX = script.cube.transform.position.x;
+        Assert.AreEqual(startX, endX, 0.1f);
+
+        // Wait for particle to finish (duration is 1s)
+        yield return new WaitForSeconds(1f);
+        Assert.IsFalse(script.particle.isPlaying);
+    }
+}
+#endif

--- a/TestUnity/Assets/Tests/PlayMode/CubePlayModeTests.cs.meta
+++ b/TestUnity/Assets/Tests/PlayMode/CubePlayModeTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8fff8658477b43f686c4a40e5dbff77e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/TestUnity/Assets/Tests/PlayMode/Tests.asmdef
+++ b/TestUnity/Assets/Tests/PlayMode/Tests.asmdef
@@ -1,0 +1,15 @@
+{
+  "name": "PlayModeTests",
+  "references": ["RuntimeScripts"],
+  "optionalUnityReferences": ["TestAssemblies"],
+  "includePlatforms": [],
+  "excludePlatforms": [],
+  "allowUnsafeCode": false,
+  "overrideReferences": false,
+  "precompiledReferences": [],
+  "autoReferenced": false,
+  "defineConstraints": [],
+  "versionDefines": [],
+  "noEngineReferences": false,
+  "testAssemblies": true
+}

--- a/TestUnity/Assets/Tests/PlayMode/Tests.asmdef.meta
+++ b/TestUnity/Assets/Tests/PlayMode/Tests.asmdef.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c6c9f2ed01cc49a38f1ab4858e945cb6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/TestUnity/Packages/manifest.json
+++ b/TestUnity/Packages/manifest.json
@@ -26,6 +26,7 @@
     "com.unity.modules.unitywebrequestaudio": "1.0.0",
     "com.unity.modules.unitywebrequesttexture": "1.0.0",
     "com.unity.modules.unitywebrequestwww": "1.0.0",
+    "com.unity.test-framework": "1.1.33",
     "com.unity.modules.vehicles": "1.0.0",
     "com.unity.modules.video": "1.0.0",
     "com.unity.modules.vr": "1.0.0",

--- a/TestUnity/Packages/packages-lock.json
+++ b/TestUnity/Packages/packages-lock.json
@@ -1,5 +1,23 @@
 {
   "dependencies": {
+    "com.unity.ext.nunit": {
+      "version": "1.0.6",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.test-framework": {
+      "version": "1.1.33",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.ext.nunit": "1.0.6",
+        "com.unity.modules.imgui": "1.0.0",
+        "com.unity.modules.jsonserialize": "1.0.0"
+      },
+      "url": "https://packages.unity.com"
+    },
     "com.unity.modules.ai": {
       "version": "1.0.0",
       "depth": 0,


### PR DESCRIPTION
## Summary
- implement `TestScript` to move a cube left and right while playing a particle effect
- create runtime assembly for scripts
- add play mode test verifying cube motion and particle completion
- include Unity Test Framework package

## Testing
- `unity-editor -batchmode -nographics -projectPath TestUnity -runTests -testPlatform playmode -testResults results.xml -logFile unity.log -quit`