### PR TITLE
Fix particle material and looping

### DIFF
--- a/TestUnity/Assets/Scripts/TestScript.cs
+++ b/TestUnity/Assets/Scripts/TestScript.cs
@@ -14,10 +14,17 @@ public class TestScript : MonoBehaviour
         // Add a simple particle system to the cube
         particle = cube.AddComponent<ParticleSystem>();
         particle.Stop(true, ParticleSystemStopBehavior.StopEmittingAndClear);
+
+        // Configure particle system to loop while the cube exists
         var main = particle.main;
         main.duration = 1f;
         main.startLifetime = 0.5f;
-        main.loop = false;
+        main.loop = true;
+
+        // Ensure the particle uses a valid material so it is not shown as a purple square
+        var renderer = particle.GetComponent<ParticleSystemRenderer>();
+        renderer.material = new Material(Shader.Find("Sprites/Default"));
+
         particle.Play();
 
         Debug.Log("Cube created and particle started");

--- a/TestUnity/Assets/Tests/PlayMode/CubePlayModeTests.cs
+++ b/TestUnity/Assets/Tests/PlayMode/CubePlayModeTests.cs
@@ -25,7 +25,7 @@ public class CubePlayModeTests
     }
 
     [UnityTest]
-    public IEnumerator CubeMovesLeftRightAndParticlePlays()
+    public IEnumerator CubeMovesLeftRightAndParticleContinuesToPlay()
     {
         Assert.IsNotNull(script.cube);
         Assert.IsNotNull(script.particle);
@@ -36,18 +36,21 @@ public class CubePlayModeTests
         yield return new WaitForSeconds(0.5f);
         float rightX = script.cube.transform.position.x;
         Assert.Greater(rightX, startX);
+        Assert.IsTrue(script.particle.isPlaying);
 
         yield return new WaitForSeconds(1.0f);
         float leftX = script.cube.transform.position.x;
         Assert.Less(leftX, startX);
+        Assert.IsTrue(script.particle.isPlaying);
 
         yield return new WaitForSeconds(0.5f);
         float endX = script.cube.transform.position.x;
         Assert.AreEqual(startX, endX, 0.1f);
+        Assert.IsTrue(script.particle.isPlaying);
 
-        // Wait for particle to finish (duration is 1s)
+        // Ensure particle keeps playing beyond the original duration
         yield return new WaitForSeconds(1f);
-        Assert.IsFalse(script.particle.isPlaying);
+        Assert.IsTrue(script.particle.isPlaying);
     }
 }
 #endif

--- a/TestUnity/ProjectSettings/ProjectSettings.asset
+++ b/TestUnity/ProjectSettings/ProjectSettings.asset
@@ -78,7 +78,7 @@ PlayerSettings:
   androidFullscreenMode: 1
   defaultIsNativeResolution: 1
   macRetinaSupport: 1
-  runInBackground: 0
+  runInBackground: 1
   captureSingleScreen: 0
   muteOtherAudioSources: 0
   Prepare IOS For Recording: 0
@@ -152,13 +152,17 @@ PlayerSettings:
   useHDRDisplay: 0
   hdrBitDepth: 0
   m_ColorGamuts: 00000000
-  targetPixelDensity: 0
+  targetPixelDensity: 30
   resolutionScalingMode: 0
   resetResolutionOnWindowResize: 0
   androidSupportedAspectRatio: 1
   androidMaxAspectRatio: 2.1
   applicationIdentifier: {}
-  buildNumber: {}
+  buildNumber:
+    Standalone: 0
+    VisionOS: 0
+    iPhone: 0
+    tvOS: 0
   overrideDefaultApplicationIdentifier: 0
   AndroidBundleVersionCode: 1
   AndroidMinSdkVersion: 22
@@ -177,12 +181,12 @@ PlayerSettings:
   strictShaderVariantMatching: 0
   VertexChannelCompressionMask: 4054
   iPhoneSdkVersion: 988
-  iOSTargetOSVersionString: 
+  iOSTargetOSVersionString: 12.0
   tvOSSdkVersion: 0
   tvOSRequireExtendedGameController: 0
-  tvOSTargetOSVersionString: 
+  tvOSTargetOSVersionString: 12.0
   VisionOSSdkVersion: 0
-  VisionOSTargetOSVersionString: 
+  VisionOSTargetOSVersionString: 1.0
   uIPrerenderedIcon: 0
   uIRequiresPersistentWiFi: 0
   uIRequiresFullScreen: 1
@@ -309,7 +313,7 @@ PlayerSettings:
   locationUsageDescription: 
   microphoneUsageDescription: 
   bluetoothUsageDescription: 
-  macOSTargetOSVersion: 
+  macOSTargetOSVersion: 10.13.0
   switchNMETAOverride: 
   switchNetLibKey: 
   switchSocketMemoryPoolSize: 6144


### PR DESCRIPTION
## Summary
- fix particle renderer to avoid purple square
- keep particle system playing while cube moves
- update PlayMode test for looping particle
- enable play mode to run in background in ProjectSettings

## Testing
- `unity-editor -batchmode -nographics -projectPath TestUnity -runTests -testPlatform PlayMode -logFile playmode.log`