### PR TITLE
Add cube movement with particle effect and tests

### DIFF
--- a/TestUnity/Assets/Scripts/CubeMover.cs
+++ b/TestUnity/Assets/Scripts/CubeMover.cs
@@ -1,0 +1,25 @@
+using UnityEngine;
+
+public class CubeMover : MonoBehaviour
+{
+    public float amplitude = 1f;
+    public float frequency = 1f; // cycles per second
+
+    private Vector3 startPos;
+    private ParticleSystem particles;
+
+    void Start()
+    {
+        startPos = transform.position;
+        particles = gameObject.AddComponent<ParticleSystem>();
+        var main = particles.main;
+        main.loop = true;
+        particles.Play();
+    }
+
+    void Update()
+    {
+        float x = Mathf.Sin(Time.time * 2f * Mathf.PI * frequency) * amplitude;
+        transform.position = startPos + Vector3.right * x;
+    }
+}

--- a/TestUnity/Assets/Scripts/CubeMover.cs.meta
+++ b/TestUnity/Assets/Scripts/CubeMover.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 65569f3effad4296b93bdcab3291837a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Scripts/Runtime.asmdef
+++ b/TestUnity/Assets/Scripts/Runtime.asmdef
@@ -1,0 +1,13 @@
+{
+  "name": "Runtime",
+  "references": [],
+  "includePlatforms": [],
+  "excludePlatforms": [],
+  "allowUnsafeCode": false,
+  "overrideReferences": false,
+  "precompiledReferences": [],
+  "autoReferenced": true,
+  "defineConstraints": [],
+  "versionDefines": [],
+  "noEngineReferences": false
+}

--- a/TestUnity/Assets/Scripts/Runtime.asmdef.meta
+++ b/TestUnity/Assets/Scripts/Runtime.asmdef.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ed4c7de4750446b783b982cb6f916f14
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/TestUnity/Assets/Scripts/TestScript.cs
+++ b/TestUnity/Assets/Scripts/TestScript.cs
@@ -4,9 +4,10 @@ public class TestScript : MonoBehaviour
 {
     void Start()
     {
-        // Create a cube and move it up slightly
+        // Create a cube and add movement with particles
         GameObject cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
         cube.transform.position = new Vector3(0, 1, 0);
-        Debug.Log("Cube created and positioned");
+        cube.AddComponent<CubeMover>();
+        Debug.Log("Cube created with movement and particles");
     }
 }

--- a/TestUnity/Assets/Tests.meta
+++ b/TestUnity/Assets/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 80d1516ba99daf1dd998a75f03a153dc
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Tests/PlayMode.meta
+++ b/TestUnity/Assets/Tests/PlayMode.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3c3a6d3da2687e4da89c2f5fe19a3709
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Tests/PlayMode/CubeMovementTests.cs
+++ b/TestUnity/Assets/Tests/PlayMode/CubeMovementTests.cs
@@ -1,0 +1,30 @@
+using System.Collections;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+public class CubeMovementTests
+{
+    [UnityTest]
+    public IEnumerator CubeMovesLeftRightAndParticlesPlay()
+    {
+        var go = new GameObject("Cube");
+        var mover = go.AddComponent<CubeMover>();
+        mover.frequency = 1f;
+        mover.amplitude = 1f;
+
+        // wait a frame so CubeMover.Start adds the ParticleSystem
+        yield return null;
+        var ps = go.GetComponent<ParticleSystem>();
+        Vector3 startPos = go.transform.position;
+        yield return new WaitForSeconds(0.6f);
+        Vector3 midPos = go.transform.position;
+        yield return new WaitForSeconds(0.6f);
+        Vector3 endPos = go.transform.position;
+
+        Assert.AreNotEqual(startPos.x, midPos.x);
+        Assert.AreNotEqual(midPos.x, endPos.x);
+        Assert.IsTrue(Mathf.Sign(midPos.x) != Mathf.Sign(endPos.x));
+        Assert.IsTrue(ps.isPlaying);
+    }
+}

--- a/TestUnity/Assets/Tests/PlayMode/CubeMovementTests.cs.meta
+++ b/TestUnity/Assets/Tests/PlayMode/CubeMovementTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 11b9b30eea97401997e11c0933764683
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Tests/PlayMode/PlayModeTests.asmdef
+++ b/TestUnity/Assets/Tests/PlayMode/PlayModeTests.asmdef
@@ -1,0 +1,20 @@
+{
+  "name": "PlayModeTests",
+  "references": [
+    "Runtime"
+  ],
+  "optionalUnityReferences": [
+    "TestAssemblies"
+  ],
+  "includePlatforms": [],
+  "excludePlatforms": [],
+  "allowUnsafeCode": false,
+  "overrideReferences": false,
+  "precompiledReferences": [],
+  "autoReferenced": true,
+  "defineConstraints": [
+    "UNITY_INCLUDE_TESTS"
+  ],
+  "versionDefines": [],
+  "noEngineReferences": false
+}

--- a/TestUnity/Assets/Tests/PlayMode/PlayModeTests.asmdef.meta
+++ b/TestUnity/Assets/Tests/PlayMode/PlayModeTests.asmdef.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 68971960be6645ccab382dfb7b5bf83a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/TestUnity/Packages/manifest.json
+++ b/TestUnity/Packages/manifest.json
@@ -30,6 +30,7 @@
     "com.unity.modules.video": "1.0.0",
     "com.unity.modules.vr": "1.0.0",
     "com.unity.modules.wind": "1.0.0",
-    "com.unity.modules.xr": "1.0.0"
+    "com.unity.modules.xr": "1.0.0",
+    "com.unity.test-framework": "1.1.33"
   }
 }

--- a/TestUnity/Packages/packages-lock.json
+++ b/TestUnity/Packages/packages-lock.json
@@ -1,5 +1,23 @@
 {
   "dependencies": {
+    "com.unity.ext.nunit": {
+      "version": "1.0.6",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.test-framework": {
+      "version": "1.1.33",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.ext.nunit": "1.0.6",
+        "com.unity.modules.imgui": "1.0.0",
+        "com.unity.modules.jsonserialize": "1.0.0"
+      },
+      "url": "https://packages.unity.com"
+    },
     "com.unity.modules.ai": {
       "version": "1.0.0",
       "depth": 0,


### PR DESCRIPTION
## Summary
- create `CubeMover` that oscillates horizontally and plays a `ParticleSystem`
- update `TestScript` to add the mover
- add play mode test for cube movement and particles
- add runtime assembly definition and test assembly definition
- include Unity test framework packages for play mode tests

## Testing
- `unity-editor -batchmode -nographics -projectPath TestUnity -runTests -testResults results.xml -testPlatform PlayMode -logfile TestUnity/test.log`