### PR TITLE
Add cube movement with particle effect and tests

### DIFF
--- a/TestUnity/Assets/Scripts/Scripts.asmdef
+++ b/TestUnity/Assets/Scripts/Scripts.asmdef
@@ -1,0 +1,3 @@
+{
+  "name": "Scripts"
+}

--- a/TestUnity/Assets/Scripts/Scripts.asmdef.meta
+++ b/TestUnity/Assets/Scripts/Scripts.asmdef.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9fd7dddf564d4f83a8aa5dfd08ef3cee
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/TestUnity/Assets/Scripts/TestScript.cs
+++ b/TestUnity/Assets/Scripts/TestScript.cs
@@ -1,12 +1,53 @@
+using System.Collections;
 using UnityEngine;
 
 public class TestScript : MonoBehaviour
 {
+    public GameObject cube;
+    public ParticleSystem particle;
+    public bool movementFinished = false;
+    public int loops = 2;
+    public float halfCycleDuration = 0.2f;
+    public float amplitude = 1f;
+
     void Start()
     {
-        // Create a cube and move it up slightly
-        GameObject cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
-        cube.transform.position = new Vector3(0, 1, 0);
-        Debug.Log("Cube created and positioned");
+        // Create cube at left position
+        cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
+        cube.transform.position = new Vector3(-amplitude, 1f, 0f);
+
+        // Add a particle system to the cube
+        particle = cube.AddComponent<ParticleSystem>();
+        var main = particle.main;
+        main.loop = false;
+        particle.Play();
+
+        // Start movement coroutine
+        StartCoroutine(MoveCube());
+    }
+
+    IEnumerator MoveCube()
+    {
+        for (int i = 0; i < loops; i++)
+        {
+            yield return MoveSegment(-amplitude, amplitude);
+            yield return MoveSegment(amplitude, -amplitude);
+        }
+        particle.Stop(true, ParticleSystemStopBehavior.StopEmittingAndClear);
+        movementFinished = true;
+    }
+
+    IEnumerator MoveSegment(float startX, float endX)
+    {
+        float t = 0f;
+        while (t < halfCycleDuration)
+        {
+            float progress = t / halfCycleDuration;
+            float x = Mathf.Lerp(startX, endX, progress);
+            cube.transform.position = new Vector3(x, 1f, 0f);
+            t += Time.deltaTime;
+            yield return null;
+        }
+        cube.transform.position = new Vector3(endX, 1f, 0f);
     }
 }

--- a/TestUnity/Assets/Tests.meta
+++ b/TestUnity/Assets/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fbfb5e0513374e9591c618daa5ef04ac
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/TestUnity/Assets/Tests/PlayMode.meta
+++ b/TestUnity/Assets/Tests/PlayMode.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: dd8a7b53c3624b6aa60b1f3d1942a2d0
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/TestUnity/Assets/Tests/PlayMode/CubeMovementTests.cs
+++ b/TestUnity/Assets/Tests/PlayMode/CubeMovementTests.cs
@@ -1,0 +1,30 @@
+using System.Collections;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+[TestFixture]
+public class CubeMovementTests
+{
+    [UnityTest]
+    public IEnumerator CubeMovesAndParticlePlays()
+    {
+        var go = new GameObject();
+        var script = go.AddComponent<TestScript>();
+
+        // Wait until cube is created
+        yield return new WaitUntil(() => script.cube != null);
+
+        // Wait until cube reaches right side
+        yield return new WaitUntil(() => script.cube.transform.position.x > 0.9f);
+        Assert.IsTrue(script.particle.isPlaying, "Particle should be playing while moving");
+
+        // Wait until cube reaches left side
+        yield return new WaitUntil(() => script.cube.transform.position.x < -0.9f);
+        Assert.IsTrue(script.particle.isPlaying, "Particle should still be playing");
+
+        // Wait for movement to finish
+        yield return new WaitUntil(() => script.movementFinished);
+        Assert.IsFalse(script.particle.isPlaying, "Particle should stop after movement ends");
+    }
+}

--- a/TestUnity/Assets/Tests/PlayMode/CubeMovementTests.cs.meta
+++ b/TestUnity/Assets/Tests/PlayMode/CubeMovementTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 34584b47905145278fd8dd3dac68d407
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/TestUnity/Assets/Tests/PlayMode/PlayModeTests.asmdef
+++ b/TestUnity/Assets/Tests/PlayMode/PlayModeTests.asmdef
@@ -1,0 +1,6 @@
+{
+  "name": "PlayModeTests",
+  "optionalUnityReferences": ["TestAssemblies"],
+  "references": ["Scripts"],
+  "testAssemblies": true
+}

--- a/TestUnity/Assets/Tests/PlayMode/PlayModeTests.asmdef.meta
+++ b/TestUnity/Assets/Tests/PlayMode/PlayModeTests.asmdef.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9d339615cae8425285178bce8a4c1322
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/TestUnity/Packages/manifest.json
+++ b/TestUnity/Packages/manifest.json
@@ -30,6 +30,7 @@
     "com.unity.modules.video": "1.0.0",
     "com.unity.modules.vr": "1.0.0",
     "com.unity.modules.wind": "1.0.0",
-    "com.unity.modules.xr": "1.0.0"
+    "com.unity.modules.xr": "1.0.0",
+    "com.unity.test-framework": "1.1.33"
   }
 }

--- a/TestUnity/Packages/packages-lock.json
+++ b/TestUnity/Packages/packages-lock.json
@@ -1,5 +1,23 @@
 {
   "dependencies": {
+    "com.unity.ext.nunit": {
+      "version": "1.0.6",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.test-framework": {
+      "version": "1.1.33",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.ext.nunit": "1.0.6",
+        "com.unity.modules.imgui": "1.0.0",
+        "com.unity.modules.jsonserialize": "1.0.0"
+      },
+      "url": "https://packages.unity.com"
+    },
     "com.unity.modules.ai": {
       "version": "1.0.0",
       "depth": 0,


### PR DESCRIPTION
## Summary
- animate a cube left and right with particle effect
- ensure particle stops after animation
- add play mode test verifying cube motion and particle
- add asmdefs to enable testing
- enable test framework in manifest

## Testing
- `unity-editor -batchmode -nographics -projectPath TestUnity -runTests -testPlatform PlayMode -assemblyNames PlayModeTests -testResults results.xml -logFile unity-test.log`
