### PR TITLE
Implement basic rotating arena game

### DIFF
--- a/TestUnity/Assets/Editor/BatchBoot.cs.meta
+++ b/TestUnity/Assets/Editor/BatchBoot.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: eb3ab134d9b865329b2c878da85c5abf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Editor/CompileFailExit.cs.meta
+++ b/TestUnity/Assets/Editor/CompileFailExit.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 31f8d356a4ae0a2fda595dce8e499893
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Editor/GenerateUnityTests.cs.meta
+++ b/TestUnity/Assets/Editor/GenerateUnityTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dd1c540b52f92454d941c750e8ee7207
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Editor/LogSplitter.cs.meta
+++ b/TestUnity/Assets/Editor/LogSplitter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e7282fee233981fb0b4a12a54626d351
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Scripts/GameManager.cs
+++ b/TestUnity/Assets/Scripts/GameManager.cs
@@ -1,0 +1,143 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+public class SimpleText : MonoBehaviour
+{
+    public string text;
+}
+
+public class GameManager : MonoBehaviour
+{
+    public float timeLimit = 30f;
+    public int targetCount = 20;
+    public float arenaSize = 5f;
+    public float rotationSpeed = 60f;
+
+    private float _time;
+    private int _score;
+    public SimpleText scoreText;
+    public SimpleText timeText;
+    public Transform arenaRoot;
+    public GameObject ballPrefab;
+    public GameObject targetPrefab;
+    private readonly List<GameObject> _targets = new List<GameObject>();
+    public bool GameOver { get; private set; }
+
+    public void Start()
+    {
+        if (!arenaRoot) CreateArena();
+        if (!ballPrefab) ballPrefab = CreateBallPrefab();
+        if (!targetPrefab) targetPrefab = CreateTargetPrefab();
+
+        SpawnBall();
+        SpawnTargets();
+        UpdateUI();
+    }
+
+    void Update()
+    {
+        Tick(Time.deltaTime, Input.GetAxis("Horizontal"));
+    }
+
+    public void Tick(float dt, float input)
+    {
+        if (GameOver) return;
+
+        _time += dt;
+        RotateArena(input, dt);
+        if (_time >= timeLimit)
+            EndGame();
+        UpdateUI();
+    }
+
+    public void RegisterHit(Target t)
+    {
+        if (GameOver) return;
+        _score++;
+        _targets.Remove(t.gameObject);
+        if (_targets.Count == 0)
+            EndGame();
+        UpdateUI();
+    }
+
+    void EndGame()
+    {
+        GameOver = true;
+    }
+
+    void UpdateUI()
+    {
+        if (scoreText) scoreText.text = $"SCORE: {_score}";
+        if (timeText) timeText.text = $"TIME: {_time:F2}";
+    }
+
+    void RotateArena(float input, float dt)
+    {
+        if (arenaRoot)
+            arenaRoot.Rotate(0f, 0f, input * rotationSpeed * dt);
+    }
+
+    void CreateArena()
+    {
+        var root = new GameObject("ArenaRoot");
+        arenaRoot = root.transform;
+
+        var floor = GameObject.CreatePrimitive(PrimitiveType.Plane);
+        floor.transform.SetParent(arenaRoot);
+        floor.transform.localScale = Vector3.one;
+        floor.transform.rotation = Quaternion.Euler(0f, 45f, 0f);
+
+        float half = arenaSize;
+        CreateWall(new Vector3(-half, 0.5f, 0f));
+        CreateWall(new Vector3(half, 0.5f, 0f));
+        CreateWall(new Vector3(0f, 0.5f, -half));
+        CreateWall(new Vector3(0f, 0.5f, half));
+    }
+
+    void CreateWall(Vector3 pos)
+    {
+        var wall = GameObject.CreatePrimitive(PrimitiveType.Cube);
+        wall.transform.SetParent(arenaRoot);
+        wall.transform.localScale = new Vector3(arenaSize * 2f, 1f, 1f);
+        wall.transform.position = pos;
+    }
+
+    GameObject CreateBallPrefab()
+    {
+        var ball = GameObject.CreatePrimitive(PrimitiveType.Sphere);
+        ball.AddComponent<Rigidbody>();
+        ball.AddComponent<BallMarker>();
+        return ball;
+    }
+
+    GameObject CreateTargetPrefab()
+    {
+        var target = GameObject.CreatePrimitive(PrimitiveType.Sphere);
+        var sc = target.AddComponent<SphereCollider>();
+        sc.isTrigger = true;
+        target.AddComponent<Target>();
+        return target;
+    }
+
+    void SpawnBall()
+    {
+        var obj = Instantiate(ballPrefab, Vector3.zero, Quaternion.identity);
+        obj.name = "Ball";
+    }
+
+    void SpawnTargets()
+    {
+        var rng = new System.Random(0);
+        for (int i = 0; i < targetCount; i++)
+        {
+            float x = (float)(rng.NextDouble() * arenaSize - arenaSize / 2);
+            float z = (float)(rng.NextDouble() * arenaSize - arenaSize / 2);
+            var target = Instantiate(targetPrefab, new Vector3(x, 0.5f, z), Quaternion.identity);
+            target.SetActive(true);
+            target.GetComponent<Target>().manager = this;
+            _targets.Add(target);
+        }
+    }
+}
+
+public class BallMarker : MonoBehaviour {}

--- a/TestUnity/Assets/Scripts/GameManager.cs.meta
+++ b/TestUnity/Assets/Scripts/GameManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 08cdc577c9cd35f5b9c71ba2ad2e1ec7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Scripts/Target.cs
+++ b/TestUnity/Assets/Scripts/Target.cs
@@ -1,0 +1,15 @@
+using UnityEngine;
+
+public class Target : MonoBehaviour
+{
+    public GameManager manager;
+
+    void OnTriggerEnter(Collider other)
+    {
+        if (other.GetComponent<BallMarker>())
+        {
+            manager.RegisterHit(this);
+            Destroy(gameObject);
+        }
+    }
+}

--- a/TestUnity/Assets/Scripts/Target.cs.meta
+++ b/TestUnity/Assets/Scripts/Target.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a1988cde30f1ebc2bafee4d8a6b3acef
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Tests.meta
+++ b/TestUnity/Assets/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0c2d43145e0b8110a923175047bcd466
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Tests/Editor.meta
+++ b/TestUnity/Assets/Tests/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5174387c51ace2016936434765921ab2
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Tests/Editor/GameManagerTests.cs
+++ b/TestUnity/Assets/Tests/Editor/GameManagerTests.cs
@@ -1,0 +1,115 @@
+using NUnit.Framework;
+using UnityEngine;
+
+public class GameManagerTests
+{
+    GameManager CreateManager(int targetCount = 3, float timeLimit = 30f)
+    {
+        var go = new GameObject("GM");
+        var gm = go.AddComponent<GameManager>();
+        gm.targetCount = targetCount;
+        gm.timeLimit = timeLimit;
+        gm.scoreText = new GameObject("score").AddComponent<SimpleText>();
+        gm.timeText = new GameObject("time").AddComponent<SimpleText>();
+        gm.ballPrefab = new GameObject("ball");
+        gm.ballPrefab.AddComponent<BallMarker>();
+        gm.ballPrefab.AddComponent<SphereCollider>();
+        gm.ballPrefab.AddComponent<Rigidbody>();
+        gm.ballPrefab.SetActive(false);
+        gm.targetPrefab = new GameObject("target");
+        gm.targetPrefab.AddComponent<Target>();
+        gm.targetPrefab.AddComponent<SphereCollider>().isTrigger = true;
+        gm.targetPrefab.GetComponent<Target>().manager = gm;
+        gm.targetPrefab.SetActive(false);
+        gm.Start();
+        return gm;
+    }
+
+    [Test]
+    public void CreatesArenaAndTargets()
+    {
+        var gm = CreateManager();
+        Assert.IsNotNull(gm.arenaRoot);
+        var list = (System.Collections.Generic.List<GameObject>)typeof(GameManager)
+            .GetField("_targets", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
+            .GetValue(gm);
+        Assert.AreEqual(3, list.Count);
+    }
+
+    [Test]
+    public void InitialScoreIsZero()
+    {
+        var gm = CreateManager();
+        Assert.AreEqual("SCORE: 0", gm.scoreText.text);
+    }
+
+    [Test]
+    public void RegisterHitIncrementsScore()
+    {
+        var gm = CreateManager();
+        var target = Object.FindObjectOfType<Target>(true);
+        gm.RegisterHit(target);
+        Assert.AreEqual(1, gm.GetType().GetField("_score", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance).GetValue(gm));
+    }
+
+    [Test]
+    public void GameEndsWhenTargetsGone()
+    {
+        var gm = CreateManager(1);
+        var target = Object.FindObjectOfType<Target>(true);
+        gm.RegisterHit(target);
+        Assert.IsTrue(gm.GameOver);
+    }
+
+    [Test]
+    public void TickAdvancesTime()
+    {
+        var gm = CreateManager();
+        gm.Tick(1f, 0f);
+        Assert.AreEqual(1f, gm.GetType().GetField("_time", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance).GetValue(gm));
+    }
+
+    [Test]
+    public void GameEndsWhenTimeLimitReached()
+    {
+        var gm = CreateManager(1, 0.5f);
+        gm.Tick(1f, 0f);
+        Assert.IsTrue(gm.GameOver);
+    }
+
+    [Test]
+    public void RotateArenaChangesRotation()
+    {
+        var gm = CreateManager();
+        var initial = gm.arenaRoot.rotation;
+        gm.Tick(1f, 1f);
+        Assert.AreNotEqual(initial, gm.arenaRoot.rotation);
+    }
+
+    [Test]
+    public void ScoreTextUpdates()
+    {
+        var gm = CreateManager();
+        var text = gm.scoreText;
+        gm.RegisterHit(Object.FindObjectOfType<Target>(true));
+        Assert.IsTrue(text.text.Contains("1"));
+    }
+
+    [Test]
+    public void TimeTextUpdates()
+    {
+        var gm = CreateManager();
+        gm.Tick(1f, 0f);
+        Assert.IsTrue(gm.timeText.text.Contains("1.00"));
+    }
+
+    [Test]
+    public void MultipleHitsIncreaseScore()
+    {
+        var gm = CreateManager(2);
+        var targets = Object.FindObjectsOfType<Target>(true);
+        foreach (var t in targets)
+            gm.RegisterHit(t);
+        Assert.AreEqual(2, gm.GetType().GetField("_score", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance).GetValue(gm));
+    }
+}

--- a/TestUnity/Assets/Tests/Editor/GameManagerTests.cs.meta
+++ b/TestUnity/Assets/Tests/Editor/GameManagerTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0fdf3e75806b97b8bb724b17cc35a0ed
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Tests/Editor/SampleTest.cs
+++ b/TestUnity/Assets/Tests/Editor/SampleTest.cs
@@ -1,0 +1,13 @@
+using NUnit.Framework;
+
+/// <summary>
+/// サンプル用の単純な EditMode テスト
+/// </summary>
+public class SampleTest
+{
+    [Test]
+    public void Passes()
+    {
+        Assert.IsTrue(true);
+    }
+}

--- a/TestUnity/Assets/Tests/Editor/SampleTest.cs.meta
+++ b/TestUnity/Assets/Tests/Editor/SampleTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b5cafc5053a421be7ae2b61a162ca188
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Packages/packages-lock.json
+++ b/TestUnity/Packages/packages-lock.json
@@ -1,5 +1,23 @@
 {
   "dependencies": {
+    "com.unity.ext.nunit": {
+      "version": "1.0.6",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.test-framework": {
+      "version": "1.1.33",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.ext.nunit": "1.0.6",
+        "com.unity.modules.imgui": "1.0.0",
+        "com.unity.modules.jsonserialize": "1.0.0"
+      },
+      "url": "https://packages.unity.com"
+    },
     "com.unity.modules.ai": {
       "version": "1.0.0",
       "depth": 0,

--- a/TestUnity/ProjectSettings/EditorBuildSettings.asset
+++ b/TestUnity/ProjectSettings/EditorBuildSettings.asset
@@ -4,5 +4,8 @@
 EditorBuildSettings:
   m_ObjectHideFlags: 0
   serializedVersion: 2
-  m_Scenes: []
+  m_Scenes:
+  - enabled: 1
+    path: Assets/Scenes/GeneratedScene.unity
+    guid: 95b371128d69f4b44845a3724c9674fe
   m_configObjects: {}


### PR DESCRIPTION
## Summary
- create `GameManager` and `Target` scripts implementing simple arena logic
- add lightweight `SimpleText` for UI-less testing
- generate edit mode tests (`GameManagerTests`) with ten cases
- register scene in build settings via BatchBoot
- update package lock for test framework

## Testing
- `Unity -batchmode -nographics -projectPath TestUnity -forceBatchBoot`
- `Unity -batchmode -nographics -projectPath TestUnity -runTests -testPlatform editmode -testResults $PWD/TestUnity/results.xml -forceBatchBoot`

------
https://chatgpt.com/codex/tasks/task_e_684031763af48328884023e129f9c2ae