### PR TITLE
Add basic puzzle game scripts with tests

### DIFF
--- a/TestUnity/Assets/Editor/BatchBoot.cs.meta
+++ b/TestUnity/Assets/Editor/BatchBoot.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 668a023063851c67f89734b38e406a78
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Editor/CompileFailExit.cs.meta
+++ b/TestUnity/Assets/Editor/CompileFailExit.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2efe3c184071fbdfdb2841dd3bc522a6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Editor/GenerateUnityTests.cs.meta
+++ b/TestUnity/Assets/Editor/GenerateUnityTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ae21004f95c3201fea94a7886db55c0f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Editor/LogSplitter.cs.meta
+++ b/TestUnity/Assets/Editor/LogSplitter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 66096a40f5486a4ec969bceb8b17a046
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Game.meta
+++ b/TestUnity/Assets/Game.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 40eddc6a1c6aa1ba7b78231bdc62e260
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Game/Scripts.meta
+++ b/TestUnity/Assets/Game/Scripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2f5ebdec64e7980bf9e55a5982a1ac2e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Game/Scripts/ArenaRotator.cs
+++ b/TestUnity/Assets/Game/Scripts/ArenaRotator.cs
@@ -1,0 +1,22 @@
+using UnityEngine;
+
+public class ArenaRotator : MonoBehaviour
+{
+    public float rotationSpeed = 60f;
+
+    /// <summary>
+    /// Rotate the arena by input amount for given delta time.
+    /// </summary>
+    /// <param name="input">-1 to 1 value.</param>
+    /// <param name="deltaTime">Delta time in seconds.</param>
+    public void ApplyRotation(float input, float deltaTime)
+    {
+        transform.Rotate(Vector3.forward, rotationSpeed * input * deltaTime, Space.World);
+    }
+
+    void Update()
+    {
+        float input = Input.GetAxis("Horizontal");
+        ApplyRotation(input, Time.deltaTime);
+    }
+}

--- a/TestUnity/Assets/Game/Scripts/ArenaRotator.cs.meta
+++ b/TestUnity/Assets/Game/Scripts/ArenaRotator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6f78f23fb9cafa807be5547bda90ce50
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Game/Scripts/BallController.cs
+++ b/TestUnity/Assets/Game/Scripts/BallController.cs
@@ -1,0 +1,30 @@
+using UnityEngine;
+
+[RequireComponent(typeof(Rigidbody), typeof(SphereCollider))]
+public class BallController : MonoBehaviour
+{
+    private void Awake()
+    {
+        SetupPhysics();
+    }
+
+    /// <summary>
+    /// Configure rigidbody and collider material. Exposed for tests.
+    /// </summary>
+    public void SetupPhysics()
+    {
+        var rb = GetComponent<Rigidbody>();
+        rb.mass = 1f;
+        rb.useGravity = true;
+
+        var col = GetComponent<SphereCollider>();
+        var mat = new PhysicMaterial
+        {
+            bounciness = 0.9f,
+            dynamicFriction = 0f,
+            staticFriction = 0f,
+            bounceCombine = PhysicMaterialCombine.Maximum
+        };
+        col.material = mat;
+    }
+}

--- a/TestUnity/Assets/Game/Scripts/BallController.cs.meta
+++ b/TestUnity/Assets/Game/Scripts/BallController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1de237a80708dcff89dc4e268c100270
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Game/Scripts/GameController.cs
+++ b/TestUnity/Assets/Game/Scripts/GameController.cs
@@ -1,0 +1,78 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+public class GameController : MonoBehaviour
+{
+    public BallController ballPrefab;
+    public Target targetPrefab;
+    public int targetCount = 20;
+    public float timeLimit = 30f;
+
+    public int Score { get; private set; }
+    public float TimeRemaining { get; private set; }
+    public bool GameOver { get; private set; }
+    public int ActiveTargetCount => _targets.Count;
+
+    private BallController _ballInstance;
+    private readonly List<Target> _targets = new List<Target>();
+
+    public void StartGame()
+    {
+        ClearExisting();
+
+        _ballInstance = Instantiate(ballPrefab, Vector3.zero, Quaternion.identity);
+        TimeRemaining = timeLimit;
+        Score = 0;
+        GameOver = false;
+
+        for (int i = 0; i < targetCount; i++)
+        {
+            Vector3 pos = new Vector3(i % 5 - 2, 0.5f, i / 5 - 2);
+            Target t = Instantiate(targetPrefab, pos, Quaternion.identity);
+            _targets.Add(t);
+        }
+    }
+
+    public void Tick(float dt)
+    {
+        if (GameOver)
+            return;
+
+        TimeRemaining -= dt;
+        if (TimeRemaining <= 0f)
+        {
+            TimeRemaining = 0f;
+            GameOver = true;
+            return;
+        }
+
+        _targets.RemoveAll(t => t == null);
+        if (_targets.Count == 0)
+        {
+            GameOver = true;
+        }
+    }
+
+    public void TargetDestroyed(Target t)
+    {
+        Score += 1;
+        _targets.Remove(t);
+    }
+
+    private void ClearExisting()
+    {
+        if (_ballInstance)
+            DestroyImmediate(_ballInstance.gameObject);
+        foreach (var t in _targets)
+        {
+            if (t)
+                DestroyImmediate(t.gameObject);
+        }
+        _targets.Clear();
+    }
+
+    void Update()
+    {
+        Tick(Time.deltaTime);
+    }
+}

--- a/TestUnity/Assets/Game/Scripts/GameController.cs.meta
+++ b/TestUnity/Assets/Game/Scripts/GameController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b52a6341dae6b67859df1a3c8ea8884c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Game/Scripts/Target.cs
+++ b/TestUnity/Assets/Game/Scripts/Target.cs
@@ -1,0 +1,22 @@
+using UnityEngine;
+
+[RequireComponent(typeof(SphereCollider))]
+public class Target : MonoBehaviour
+{
+    private void Reset()
+    {
+        var col = GetComponent<SphereCollider>();
+        col.isTrigger = true;
+    }
+
+    private void OnTriggerEnter(Collider other)
+    {
+        if (other.GetComponent<BallController>() != null)
+        {
+            var gc = FindObjectOfType<GameController>();
+            if (gc != null)
+                gc.TargetDestroyed(this);
+            Destroy(gameObject);
+        }
+    }
+}

--- a/TestUnity/Assets/Game/Scripts/Target.cs.meta
+++ b/TestUnity/Assets/Game/Scripts/Target.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 85ccd056258dfc9bba3da4570a8c515f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Tests.meta
+++ b/TestUnity/Assets/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fec8186061cb5e7a7a182e6ab3639381
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Tests/Editor.meta
+++ b/TestUnity/Assets/Tests/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6c45d93ec97c53920af27f85f389fb94
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Tests/Editor/GameTests.cs
+++ b/TestUnity/Assets/Tests/Editor/GameTests.cs
@@ -1,0 +1,114 @@
+using NUnit.Framework;
+using UnityEngine;
+
+public class GameTests
+{
+    [Test]
+    public void ArenaRotatesPositive()
+    {
+        var go = new GameObject();
+        var rotator = go.AddComponent<ArenaRotator>();
+        rotator.rotationSpeed = 60f;
+        rotator.ApplyRotation(1f, 1f);
+        Assert.AreEqual(60f, go.transform.eulerAngles.z, 0.1f);
+    }
+
+    [Test]
+    public void ArenaRotatesNegative()
+    {
+        var go = new GameObject();
+        var rotator = go.AddComponent<ArenaRotator>();
+        rotator.rotationSpeed = 60f;
+        rotator.ApplyRotation(-1f, 1f);
+        float angle = go.transform.eulerAngles.z;
+        if (angle > 180f) angle -= 360f;
+        Assert.AreEqual(-60f, angle, 0.1f);
+    }
+
+    [Test]
+    public void TimerCountsDown()
+    {
+        var obj = new GameObject();
+        var gc = obj.AddComponent<GameController>();
+        gc.ballPrefab = new GameObject().AddComponent<BallController>();
+        gc.targetPrefab = new GameObject().AddComponent<Target>();
+        gc.StartGame();
+        gc.Tick(1f);
+        Assert.Less(gc.TimeRemaining, gc.timeLimit);
+    }
+
+    [Test]
+    public void GameEndsWhenTimeUp()
+    {
+        var obj = new GameObject();
+        var gc = obj.AddComponent<GameController>();
+        gc.ballPrefab = new GameObject().AddComponent<BallController>();
+        gc.targetPrefab = new GameObject().AddComponent<Target>();
+        gc.timeLimit = 1f;
+        gc.StartGame();
+        gc.Tick(1.1f);
+        Assert.IsTrue(gc.GameOver);
+    }
+
+    [Test]
+    public void ScoreIncrementsOnTargetDestroyed()
+    {
+        var obj = new GameObject();
+        var gc = obj.AddComponent<GameController>();
+        gc.ballPrefab = new GameObject().AddComponent<BallController>();
+        gc.targetPrefab = new GameObject().AddComponent<Target>();
+        gc.StartGame();
+        var t = gc.targetPrefab;
+        gc.TargetDestroyed(t);
+        Assert.AreEqual(1, gc.Score);
+    }
+
+    [Test]
+    public void GameEndsWhenAllTargetsGone()
+    {
+        var obj = new GameObject();
+        var gc = obj.AddComponent<GameController>();
+        gc.ballPrefab = new GameObject().AddComponent<BallController>();
+        gc.targetPrefab = new GameObject().AddComponent<Target>();
+        gc.targetCount = 1;
+        gc.StartGame();
+        var target = GameObject.FindObjectOfType<Target>();
+        gc.TargetDestroyed(target);
+        gc.Tick(0.1f);
+        Assert.IsTrue(gc.GameOver);
+    }
+
+    [Test]
+    public void BallSpawnedAtOrigin()
+    {
+        var obj = new GameObject();
+        var gc = obj.AddComponent<GameController>();
+        gc.ballPrefab = new GameObject().AddComponent<BallController>();
+        gc.targetPrefab = new GameObject().AddComponent<Target>();
+        gc.StartGame();
+        Assert.NotNull(GameObject.FindObjectOfType<BallController>());
+        Assert.AreEqual(Vector3.zero, GameObject.FindObjectOfType<BallController>().transform.position);
+    }
+
+    [Test]
+    public void TargetsSpawnedCount()
+    {
+        var obj = new GameObject();
+        var gc = obj.AddComponent<GameController>();
+        gc.ballPrefab = new GameObject().AddComponent<BallController>();
+        gc.targetPrefab = new GameObject().AddComponent<Target>();
+        gc.targetCount = 20;
+        gc.StartGame();
+        Assert.AreEqual(20, gc.ActiveTargetCount);
+    }
+
+    [Test]
+    public void BallHasHighBounciness()
+    {
+        var ball = new GameObject();
+        var bc = ball.AddComponent<BallController>();
+        bc.SetupPhysics();
+        var col = ball.GetComponent<SphereCollider>();
+        Assert.GreaterOrEqual(col.material.bounciness, 0.8f);
+    }
+}

--- a/TestUnity/Assets/Tests/Editor/GameTests.cs.meta
+++ b/TestUnity/Assets/Tests/Editor/GameTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 655b17ef28febb93590bb4a143b20414
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Tests/Editor/SampleTest.cs
+++ b/TestUnity/Assets/Tests/Editor/SampleTest.cs
@@ -1,0 +1,13 @@
+using NUnit.Framework;
+
+/// <summary>
+/// サンプル用の単純な EditMode テスト
+/// </summary>
+public class SampleTest
+{
+    [Test]
+    public void Passes()
+    {
+        Assert.IsTrue(true);
+    }
+}

--- a/TestUnity/Assets/Tests/Editor/SampleTest.cs.meta
+++ b/TestUnity/Assets/Tests/Editor/SampleTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9cf37d1f12fe070f08a64ecd88e0c641
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Packages/packages-lock.json
+++ b/TestUnity/Packages/packages-lock.json
@@ -1,5 +1,23 @@
 {
   "dependencies": {
+    "com.unity.ext.nunit": {
+      "version": "1.0.6",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.test-framework": {
+      "version": "1.1.33",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.ext.nunit": "1.0.6",
+        "com.unity.modules.imgui": "1.0.0",
+        "com.unity.modules.jsonserialize": "1.0.0"
+      },
+      "url": "https://packages.unity.com"
+    },
     "com.unity.modules.ai": {
       "version": "1.0.0",
       "depth": 0,

--- a/TestUnity/ProjectSettings/EditorBuildSettings.asset
+++ b/TestUnity/ProjectSettings/EditorBuildSettings.asset
@@ -4,5 +4,8 @@
 EditorBuildSettings:
   m_ObjectHideFlags: 0
   serializedVersion: 2
-  m_Scenes: []
+  m_Scenes:
+  - enabled: 1
+    path: Assets/Scenes/GeneratedScene.unity
+    guid: 95b371128d69f4b44845a3724c9674fe
   m_configObjects: {}


### PR DESCRIPTION
## Summary
- implement minimal arena rotation, ball physics, target behaviour
- add GameController with timer and scoring
- create 10 EditMode tests covering gameplay logic
- update build settings and package lock for test framework

## Testing
- `unity-editor -batchmode -nographics -projectPath TestUnity -forceBatchBoot`
- `unity-editor -batchmode -nographics -projectPath TestUnity -runTests -testResults $(pwd)/editmode-results.xml -forceBatchBoot`

------
https://chatgpt.com/codex/tasks/task_e_6841438efcc48328ad0c04f67e68be1d