### PR TITLE
Add simple puzzle game and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ TestUnity/Obj/
 unity_help.txt
 help.txt
 Unity_v2022.x.ulf
+*results.xml

--- a/TestUnity/Assets/Editor/BatchBoot.cs.meta
+++ b/TestUnity/Assets/Editor/BatchBoot.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 41af8debe9c755a9ca6e19832f3c346a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Editor/CompileFailExit.cs.meta
+++ b/TestUnity/Assets/Editor/CompileFailExit.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 475823fd083a2beecbc91a959e89541e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Editor/GenerateUnityTests.cs.meta
+++ b/TestUnity/Assets/Editor/GenerateUnityTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 098b71aa1f0a2c1d98485d48a66ca994
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Editor/LogSplitter.cs.meta
+++ b/TestUnity/Assets/Editor/LogSplitter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1f42e5e53e2cf5a9daee482b107c2bd2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Scripts/Game.meta
+++ b/TestUnity/Assets/Scripts/Game.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 409f2be8fa593667eb15f15091480b65
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Scripts/Game/Ball.cs
+++ b/TestUnity/Assets/Scripts/Game/Ball.cs
@@ -1,0 +1,46 @@
+using UnityEngine;
+
+public class Ball : MonoBehaviour
+{
+    public float speed = 5f;
+    private Vector2 direction = Vector2.up;
+    private Rigidbody2D rb;
+
+    void Awake()
+    {
+        rb = GetComponent<Rigidbody2D>();
+    }
+
+    public void Launch()
+    {
+        direction = Vector2.up;
+    }
+
+    public static Vector2 ReflectVector(Vector2 dir, Vector2 normal)
+    {
+        return Vector2.Reflect(dir, normal);
+    }
+
+    void FixedUpdate()
+    {
+        rb.velocity = direction.normalized * speed;
+    }
+
+    void OnCollisionEnter2D(Collision2D collision)
+    {
+        if (collision.contacts.Length > 0)
+        {
+            Vector2 normal = collision.contacts[0].normal;
+            direction = ReflectVector(direction, normal);
+        }
+    }
+
+    void OnTriggerEnter2D(Collider2D other)
+    {
+        var target = other.GetComponent<Target>();
+        if (target != null)
+        {
+            target.Hit();
+        }
+    }
+}

--- a/TestUnity/Assets/Scripts/Game/Ball.cs.meta
+++ b/TestUnity/Assets/Scripts/Game/Ball.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 21d23df4aa707752b92381add45fa580
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Scripts/Game/GameManager.cs
+++ b/TestUnity/Assets/Scripts/Game/GameManager.cs
@@ -1,0 +1,106 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+public class GameManager : MonoBehaviour
+{
+    public int targetCount = 5;
+    public float timeLimit = 30f;
+    public float arenaSize = 8f;
+    public float wallThickness = 0.5f;
+    public Ball ballPrefab; // not used since we create ball script directly
+
+    public Ball BallInstance { get; private set; }
+    public List<Target> Targets { get; private set; } = new List<Target>();
+    public bool GameEnded { get; private set; }
+    public int Score { get; private set; }
+    public float TimeRemaining { get; private set; }
+
+    void Start()
+    {
+        SetupScene();
+    }
+
+    public void SetupScene()
+    {
+        TimeRemaining = timeLimit;
+        GameEnded = false;
+        Score = 0;
+
+        // Playfield parent rotated 45 degrees
+        var playfield = new GameObject("Playfield");
+        playfield.transform.rotation = Quaternion.Euler(0, 0, 45f);
+        var rotator = playfield.AddComponent<WallRotator>();
+
+        // Create 4 walls
+        CreateWall(playfield.transform, new Vector2(-arenaSize / 2, 0), Vector2.one);
+        CreateWall(playfield.transform, new Vector2(arenaSize / 2, 0), Vector2.one);
+        CreateWall(playfield.transform, new Vector2(0, arenaSize / 2), new Vector2(1,1), 90f);
+        CreateWall(playfield.transform, new Vector2(0, -arenaSize / 2), new Vector2(1,1), 90f);
+
+        // Create ball
+        var ballObj = new GameObject("Ball");
+        ballObj.transform.position = Vector2.zero;
+        var rb = ballObj.AddComponent<Rigidbody2D>();
+        rb.gravityScale = 0;
+        rb.collisionDetectionMode = CollisionDetectionMode2D.Continuous;
+        var col = ballObj.AddComponent<CircleCollider2D>();
+        BallInstance = ballObj.AddComponent<Ball>();
+        BallInstance.Launch();
+
+        // Create targets
+        Targets.Clear();
+        for (int i = 0; i < targetCount; i++)
+        {
+            float angle = (360f / targetCount) * i;
+            Vector2 pos = Quaternion.Euler(0, 0, angle) * Vector2.up * (arenaSize / 3);
+            var targObj = new GameObject($"Target{i}");
+            targObj.transform.position = pos;
+            var tcol = targObj.AddComponent<CircleCollider2D>();
+            tcol.isTrigger = true;
+            var target = targObj.AddComponent<Target>();
+            target.Manager = this;
+            Targets.Add(target);
+        }
+    }
+
+    void CreateWall(Transform parent, Vector2 position, Vector2 scale, float rotation = 0f)
+    {
+        var wall = new GameObject("Wall");
+        wall.transform.SetParent(parent);
+        wall.transform.localPosition = position;
+        wall.transform.localRotation = Quaternion.Euler(0, 0, rotation);
+        wall.transform.localScale = new Vector3(wallThickness, arenaSize, 1);
+        var col = wall.AddComponent<BoxCollider2D>();
+    }
+
+    void Update()
+    {
+        if (GameEnded) return;
+
+        TimeRemaining -= Time.deltaTime;
+        if (TimeRemaining <= 0f)
+        {
+            EndGame(false);
+        }
+
+        if (Targets.Count == 0)
+        {
+            EndGame(true);
+        }
+    }
+
+    internal void TargetDestroyed(Target t)
+    {
+        if (Targets.Contains(t))
+        {
+            Targets.Remove(t);
+            Score++;
+        }
+    }
+
+    void EndGame(bool cleared)
+    {
+        GameEnded = true;
+        Debug.Log($"Game Ended {(cleared ? "Clear" : "TimeUp")} Score={Score}");
+    }
+}

--- a/TestUnity/Assets/Scripts/Game/GameManager.cs.meta
+++ b/TestUnity/Assets/Scripts/Game/GameManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9e2f73ed2d4f0e34f9c917851cafe578
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Scripts/Game/Target.cs
+++ b/TestUnity/Assets/Scripts/Game/Target.cs
@@ -1,0 +1,12 @@
+using UnityEngine;
+
+public class Target : MonoBehaviour
+{
+    public GameManager Manager { get; set; }
+
+    public void Hit()
+    {
+        Manager.TargetDestroyed(this);
+        Destroy(gameObject);
+    }
+}

--- a/TestUnity/Assets/Scripts/Game/Target.cs.meta
+++ b/TestUnity/Assets/Scripts/Game/Target.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 970ff96ec1ecd92a4bf28d67cdb50260
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Scripts/Game/WallRotator.cs
+++ b/TestUnity/Assets/Scripts/Game/WallRotator.cs
@@ -1,0 +1,18 @@
+using UnityEngine;
+
+public class WallRotator : MonoBehaviour
+{
+    public float rotationSpeed = 90f; // degrees per second
+
+    void Update()
+    {
+        float input = Input.GetAxisRaw("Horizontal");
+        ApplyRotation(input);
+    }
+
+    public void ApplyRotation(float direction, float deltaTime = -1f)
+    {
+        if (deltaTime < 0f) deltaTime = Time.deltaTime;
+        transform.Rotate(0, 0, -direction * rotationSpeed * deltaTime);
+    }
+}

--- a/TestUnity/Assets/Scripts/Game/WallRotator.cs.meta
+++ b/TestUnity/Assets/Scripts/Game/WallRotator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 95f752f1f8fb483548b9294e1b2c860e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Tests.meta
+++ b/TestUnity/Assets/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 44b4f222122c28dc091fa12514106080
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Tests/Editor.meta
+++ b/TestUnity/Assets/Tests/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0dbc31abcda411fc3b371e2406f409cd
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Tests/Editor/GameEditTests.cs
+++ b/TestUnity/Assets/Tests/Editor/GameEditTests.cs
@@ -1,0 +1,104 @@
+using NUnit.Framework;
+using UnityEngine;
+
+public class GameEditTests
+{
+    [SetUp]
+    public void Init()
+    {
+        foreach (var obj in Object.FindObjectsOfType<GameObject>())
+        {
+            if (obj.hideFlags == HideFlags.None)
+                Object.DestroyImmediate(obj);
+        }
+    }
+    [Test]
+    public void SetupCreatesPlayfield()
+    {
+        var go = new GameObject();
+        var gm = go.AddComponent<GameManager>();
+        gm.SetupScene();
+        Assert.IsNotNull(GameObject.Find("Playfield"));
+        Object.DestroyImmediate(go);
+    }
+
+    [Test]
+    public void CreatesFourWalls()
+    {
+        var go = new GameObject();
+        var gm = go.AddComponent<GameManager>();
+        gm.SetupScene();
+        int count = 0;
+        foreach (var col in GameObject.FindObjectsOfType<BoxCollider2D>())
+        {
+            if (col.gameObject.name == "Wall") count++;
+        }
+        Assert.AreEqual(4, count);
+        Object.DestroyImmediate(go);
+    }
+
+    [Test]
+    public void CreatesBall()
+    {
+        var gm = new GameObject().AddComponent<GameManager>();
+        gm.SetupScene();
+        Assert.IsNotNull(GameObject.FindObjectOfType<Ball>());
+    }
+
+    [Test]
+    public void CreatesTargets()
+    {
+        var gm = new GameObject().AddComponent<GameManager>();
+        gm.targetCount = 3;
+        gm.SetupScene();
+        Assert.AreEqual(3, GameObject.FindObjectsOfType<Target>().Length);
+    }
+
+    [Test]
+    public void BallReflectsHorizontally()
+    {
+        Vector2 reflected = Ball.ReflectVector(Vector2.right, Vector2.left);
+        Assert.AreEqual(Vector2.left, reflected);
+    }
+
+    [Test]
+    public void BallReflectsVertically()
+    {
+        Vector2 reflected = Ball.ReflectVector(Vector2.up, Vector2.down);
+        Assert.AreEqual(Vector2.down, reflected);
+    }
+
+    [Test]
+    public void WallRotatorHasDefaultSpeed()
+    {
+        var wr = new GameObject().AddComponent<WallRotator>();
+        Assert.AreEqual(90f, wr.rotationSpeed);
+    }
+
+    [Test]
+    public void GameManagerScoreStartsZero()
+    {
+        var gm = new GameObject().AddComponent<GameManager>();
+        gm.SetupScene();
+        Assert.AreEqual(0, gm.Score);
+    }
+
+    [Test]
+    public void TimeLimitDefaultThirty()
+    {
+        var gm = new GameObject().AddComponent<GameManager>();
+        Assert.AreEqual(30f, gm.timeLimit);
+    }
+
+    [Test]
+    public void TargetsHaveComponent()
+    {
+        var gm = new GameObject().AddComponent<GameManager>();
+        gm.targetCount = 2;
+        gm.SetupScene();
+        foreach (var t in GameObject.FindObjectsOfType<Target>())
+        {
+            Assert.IsNotNull(t.GetComponent<Target>());
+        }
+    }
+}

--- a/TestUnity/Assets/Tests/Editor/GameEditTests.cs.meta
+++ b/TestUnity/Assets/Tests/Editor/GameEditTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d6b3c2ed07680a2b39ce16b8a2dca16b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Tests/Editor/SampleTest.cs
+++ b/TestUnity/Assets/Tests/Editor/SampleTest.cs
@@ -1,0 +1,13 @@
+using NUnit.Framework;
+
+/// <summary>
+/// サンプル用の単純な EditMode テスト
+/// </summary>
+public class SampleTest
+{
+    [Test]
+    public void Passes()
+    {
+        Assert.IsTrue(true);
+    }
+}

--- a/TestUnity/Assets/Tests/Editor/SampleTest.cs.meta
+++ b/TestUnity/Assets/Tests/Editor/SampleTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f3c493726591c8a7085b010e864094e5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Tests/PlayMode.meta
+++ b/TestUnity/Assets/Tests/PlayMode.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7df72590b8be77fb28982fb3bc061eb5
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Tests/PlayMode/GamePlayTests.cs
+++ b/TestUnity/Assets/Tests/PlayMode/GamePlayTests.cs
@@ -1,0 +1,117 @@
+using System.Collections;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+public class GamePlayTests
+{
+    [UnityTest]
+    public IEnumerator GameNotEndedAtStart()
+    {
+        var gm = new GameObject().AddComponent<GameManager>();
+        gm.SetupScene();
+        yield return null;
+        Assert.IsFalse(gm.GameEnded);
+    }
+
+    [UnityTest]
+    public IEnumerator BallExistsOnStart()
+    {
+        var gmObj = new GameObject();
+        var gm = gmObj.AddComponent<GameManager>();
+        gm.SetupScene();
+        yield return null;
+        Assert.IsNotNull(GameObject.FindObjectOfType<Ball>());
+    }
+
+    [UnityTest]
+    public IEnumerator BallMovesConstantSpeed()
+    {
+        var gm = new GameObject().AddComponent<GameManager>();
+        gm.SetupScene();
+        var ball = gm.BallInstance;
+        yield return new WaitForFixedUpdate();
+        float speed = ball.GetComponent<Rigidbody2D>().velocity.magnitude;
+        Assert.AreEqual(ball.speed, speed, 0.01f);
+    }
+
+    [UnityTest]
+    public IEnumerator BallReflectsOnWall()
+    {
+        Vector2 reflected = Ball.ReflectVector(Vector2.right, Vector2.left);
+        Assert.AreEqual(Vector2.left, reflected);
+        yield break;
+    }
+
+    [UnityTest]
+    public IEnumerator DestroyTargetIncrementsScore()
+    {
+        var gm = new GameObject().AddComponent<GameManager>();
+        gm.targetCount = 1;
+        gm.SetupScene();
+        var target = gm.Targets[0];
+        gm.BallInstance.transform.position = target.transform.position;
+        yield return new WaitForFixedUpdate();
+        Assert.AreEqual(1, gm.Score);
+        Assert.IsTrue(gm.Targets.Count == 0);
+    }
+
+    [UnityTest]
+    public IEnumerator GameClearsWhenTargetsGone()
+    {
+        var gm = new GameObject().AddComponent<GameManager>();
+        gm.targetCount = 1;
+        gm.SetupScene();
+        gm.BallInstance.transform.position = gm.Targets[0].transform.position;
+        yield return new WaitForFixedUpdate();
+        yield return null;
+        Assert.IsTrue(gm.GameEnded);
+    }
+
+    [UnityTest]
+    public IEnumerator GameEndsOnTimeout()
+    {
+        var gm = new GameObject().AddComponent<GameManager>();
+        gm.timeLimit = 0.1f;
+        gm.SetupScene();
+        yield return new WaitForSeconds(0.2f);
+        Assert.IsTrue(gm.GameEnded);
+    }
+
+    [UnityTest]
+    public IEnumerator WallRotationChangesAngle()
+    {
+        var gm = new GameObject().AddComponent<GameManager>();
+        gm.SetupScene();
+        var rotator = GameObject.Find("Playfield").GetComponent<WallRotator>();
+        float initial = rotator.transform.eulerAngles.z;
+        rotator.ApplyRotation(1f, 1f);
+        yield return null;
+        Assert.Greater(rotator.transform.eulerAngles.z, initial);
+    }
+
+    [UnityTest]
+    public IEnumerator TimerCountsDown()
+    {
+        var gm = new GameObject().AddComponent<GameManager>();
+        gm.timeLimit = 1f;
+        gm.SetupScene();
+        float start = gm.TimeRemaining;
+        yield return new WaitForSeconds(0.5f);
+        Assert.Less(gm.TimeRemaining, start);
+    }
+
+    [UnityTest]
+    public IEnumerator BallSpeedUnchangedAfterBounce()
+    {
+        var gm = new GameObject().AddComponent<GameManager>();
+        gm.SetupScene();
+        var ball = gm.BallInstance;
+        ball.transform.position = new Vector2(gm.arenaSize/2 - 0.1f, 0);
+        yield return new WaitForFixedUpdate();
+        Vector2 dir = (Vector2)typeof(Ball).GetField("direction", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
+            .GetValue(ball);
+        float mag = dir.magnitude;
+        Assert.AreEqual(1f, mag, 0.01f);
+    }
+}

--- a/TestUnity/Assets/Tests/PlayMode/GamePlayTests.cs.meta
+++ b/TestUnity/Assets/Tests/PlayMode/GamePlayTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7a007d1c5a08cf1c18bb9ee6f296e5e3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Packages/packages-lock.json
+++ b/TestUnity/Packages/packages-lock.json
@@ -1,5 +1,23 @@
 {
   "dependencies": {
+    "com.unity.ext.nunit": {
+      "version": "1.0.6",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.test-framework": {
+      "version": "1.1.33",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.ext.nunit": "1.0.6",
+        "com.unity.modules.imgui": "1.0.0",
+        "com.unity.modules.jsonserialize": "1.0.0"
+      },
+      "url": "https://packages.unity.com"
+    },
     "com.unity.modules.ai": {
       "version": "1.0.0",
       "depth": 0,


### PR DESCRIPTION
## Summary
- implement GameManager that spawns playfield, ball, and targets
- implement Ball movement and reflection
- implement WallRotator for player input
- implement Target script
- add comprehensive EditMode and PlayMode tests
- ignore local test result files

## Testing
- `unity-editor -batchmode -nographics -projectPath TestUnity -runTests -testPlatform EditMode -testResults $(pwd)/editmode-results.xml -logFile /tmp/unity-edit.log -forceBatchBoot`
- `unity-editor -batchmode -nographics -projectPath TestUnity -runTests -testPlatform PlayMode -testResults $(pwd)/playmode-results.xml -logFile /tmp/unity-play.log -forceBatchBoot`


------
https://chatgpt.com/codex/tasks/task_e_6841599c84d08328a8ef7aeaf51dd20d