### PR TITLE
Add bouncing ball game with tests

### DIFF
--- a/TestUnity/Assets/Editor/BatchBoot.cs.meta
+++ b/TestUnity/Assets/Editor/BatchBoot.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d65f9316ce080db66b86149835d4f7ef
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Editor/CommandLine.cs
+++ b/TestUnity/Assets/Editor/CommandLine.cs
@@ -13,4 +13,14 @@ public static class CommandLine
         EditorSceneManager.SaveScene(scene, "Assets/Scenes/GeneratedScene.unity");
         Debug.Log("Scene generated and saved");
     }
+
+    // Method to create the main game scene with GameManager
+    public static void CreateGameScene()
+    {
+        var scene = EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
+        var go = new GameObject("GameManager");
+        go.AddComponent<GameManager>();
+        EditorSceneManager.SaveScene(scene, "Assets/Scenes/GameScene.unity");
+        Debug.Log("Game scene generated and saved");
+    }
 }

--- a/TestUnity/Assets/Editor/CompileFailExit.cs.meta
+++ b/TestUnity/Assets/Editor/CompileFailExit.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c6d534058606b7fb9a9affd309e6ee93
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Editor/GenerateUnityTests.cs.meta
+++ b/TestUnity/Assets/Editor/GenerateUnityTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cfcfc0375daa0171fbbf267dde592bd9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Editor/LogSplitter.cs.meta
+++ b/TestUnity/Assets/Editor/LogSplitter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bb17d498544299b1a8d90ebd62664f2d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Scenes/GameScene.unity
+++ b/TestUnity/Assets/Scenes/GameScene.unity
@@ -1,0 +1,184 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0, g: 0, b: 0, a: 1}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 12
+  m_GIWorkflowMode: 1
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 3
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    buildHeightMesh: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &754175863
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 754175865}
+  - component: {fileID: 754175864}
+  m_Layer: 0
+  m_Name: GameManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &754175864
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 754175863}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fadc0e53a3e50f137866626b037eccd9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  playTime: 30
+  elapsed: 0
+  ballPrefab: {fileID: 0}
+  targetPrefab: {fileID: 0}
+  targetCount: 5
+  targets: []
+  arenaRoot: {fileID: 0}
+  ball: {fileID: 0}
+  score: 0
+  state: 0
+--- !u!4 &754175865
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 754175863}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1660057539 &9223372036854775807
+SceneRoots:
+  m_ObjectHideFlags: 0
+  m_Roots:
+  - {fileID: 754175865}

--- a/TestUnity/Assets/Scenes/GameScene.unity.meta
+++ b/TestUnity/Assets/Scenes/GameScene.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 70e174816ea4f8551b924bc1d9c220b4
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Scripts/ArenaController.cs
+++ b/TestUnity/Assets/Scripts/ArenaController.cs
@@ -1,0 +1,12 @@
+using UnityEngine;
+
+public class ArenaController : MonoBehaviour
+{
+    public float rotationSpeed = 60f;
+    public float testInputOverride = 0f;
+    void Update()
+    {
+        float h = testInputOverride != 0f ? testInputOverride : Input.GetAxisRaw("Horizontal");
+        transform.Rotate(0,0,-h * rotationSpeed * Time.deltaTime);
+    }
+}

--- a/TestUnity/Assets/Scripts/ArenaController.cs.meta
+++ b/TestUnity/Assets/Scripts/ArenaController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5be62d2516a91f0dcab8561240801075
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Scripts/BallController.cs
+++ b/TestUnity/Assets/Scripts/BallController.cs
@@ -1,0 +1,42 @@
+using UnityEngine;
+
+[RequireComponent(typeof(Rigidbody2D))]
+public class BallController : MonoBehaviour
+{
+    public float speed = 5f;
+    Rigidbody2D rb;
+    public static bool freeze = false;
+
+    void Awake()
+    {
+        rb = GetComponent<Rigidbody2D>();
+    }
+
+    void Start()
+    {
+        if (!freeze)
+            rb.velocity = new Vector2(1, 0).normalized * speed;
+        else
+            rb.velocity = Vector2.zero;
+    }
+
+    void FixedUpdate()
+    {
+        if (freeze)
+        {
+            rb.velocity = Vector2.zero;
+            return;
+        }
+        rb.velocity = rb.velocity.normalized * speed;
+    }
+
+    void OnCollisionEnter2D(Collision2D col)
+    {
+        if (col.collider.GetComponent<Target>())
+        {
+            var gm = FindObjectOfType<GameManager>();
+            gm.TargetDestroyed(col.collider.gameObject);
+            Destroy(col.collider.gameObject);
+        }
+    }
+}

--- a/TestUnity/Assets/Scripts/BallController.cs.meta
+++ b/TestUnity/Assets/Scripts/BallController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 793676698a1c91accaf0827c5ee76389
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Scripts/GameManager.cs
+++ b/TestUnity/Assets/Scripts/GameManager.cs
@@ -1,0 +1,116 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+public class GameManager : MonoBehaviour
+{
+    public float playTime = 30f;
+    public float elapsed;
+    public GameObject ballPrefab;
+    public GameObject targetPrefab;
+    public int targetCount = 5;
+
+    public List<GameObject> targets = new List<GameObject>();
+    public GameObject arenaRoot;
+    public GameObject ball;
+    public int score;
+    public enum GameState { Playing, Cleared, TimeUp }
+    public GameState state = GameState.Playing;
+
+    public void Start()
+    {
+        SetupArena();
+        SpawnBall();
+        SpawnTargets(targetCount);
+    }
+
+    void Update()
+    {
+        if (state != GameState.Playing) return;
+        elapsed += Time.deltaTime;
+        if (elapsed >= playTime)
+        {
+            state = GameState.TimeUp;
+            Debug.Log($"Time Up! Score:{score}");
+        }
+        if (targets.Count == 0 && state == GameState.Playing)
+        {
+            state = GameState.Cleared;
+            Debug.Log($"Cleared! Time:{elapsed:F1} Score:{score}");
+        }
+    }
+
+    public void SetupArena()
+    {
+        if (arenaRoot == null)
+        {
+            arenaRoot = new GameObject("Arena");
+            CreateWalls(arenaRoot.transform, 5f);
+        }
+    }
+
+    void CreateWalls(Transform root, float halfSize)
+    {
+        Vector2[] dirs = { Vector2.up, Vector2.down, Vector2.left, Vector2.right };
+        for (int i = 0; i < 4; i++)
+        {
+            var wall = new GameObject($"Wall{i}");
+            wall.transform.SetParent(root);
+            var col = wall.AddComponent<BoxCollider2D>();
+            col.size = new Vector2(halfSize * 2, 0.2f);
+            var rb = wall.AddComponent<Rigidbody2D>();
+            rb.bodyType = RigidbodyType2D.Static;
+            wall.transform.localPosition = dirs[i] * halfSize;
+            wall.transform.localRotation = Quaternion.Euler(0,0, i %2==0?0:90);
+        }
+        root.transform.rotation = Quaternion.Euler(0,0,45);
+        root.gameObject.AddComponent<ArenaController>();
+    }
+
+    public void SpawnBall()
+    {
+        if (ballPrefab == null)
+        {
+            ball = GameObject.CreatePrimitive(PrimitiveType.Sphere);
+            ball.name = "Ball";
+#if UNITY_EDITOR
+            Object.DestroyImmediate(ball.GetComponent<SphereCollider>());
+#else
+            Destroy(ball.GetComponent<SphereCollider>());
+#endif
+            var col = ball.AddComponent<CircleCollider2D>();
+            var rb = ball.AddComponent<Rigidbody2D>();
+            rb.gravityScale = 0;
+            rb.collisionDetectionMode = CollisionDetectionMode2D.Continuous;
+            ball.AddComponent<BallController>();
+        }
+        else
+        {
+            ball = Instantiate(ballPrefab);
+        }
+    }
+
+    public void SpawnTargets(int count)
+    {
+        for (int i = 0; i < count; i++)
+        {
+            float angle = i * Mathf.PI * 2f / count;
+            Vector2 pos = new Vector2(Mathf.Cos(angle), Mathf.Sin(angle)) * 2f;
+            var target = GameObject.CreatePrimitive(PrimitiveType.Sphere);
+            target.transform.position = pos;
+#if UNITY_EDITOR
+            Object.DestroyImmediate(target.GetComponent<SphereCollider>());
+#else
+            Destroy(target.GetComponent<SphereCollider>());
+#endif
+            target.AddComponent<CircleCollider2D>();
+            target.AddComponent<Target>();
+            targets.Add(target);
+        }
+    }
+
+    public void TargetDestroyed(GameObject target)
+    {
+        targets.Remove(target);
+        score++;
+    }
+}

--- a/TestUnity/Assets/Scripts/GameManager.cs.meta
+++ b/TestUnity/Assets/Scripts/GameManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fadc0e53a3e50f137866626b037eccd9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Scripts/Target.cs
+++ b/TestUnity/Assets/Scripts/Target.cs
@@ -1,0 +1,9 @@
+using UnityEngine;
+
+public class Target : MonoBehaviour
+{
+    void OnDestroy()
+    {
+        // Placeholder for effect or sound
+    }
+}

--- a/TestUnity/Assets/Scripts/Target.cs.meta
+++ b/TestUnity/Assets/Scripts/Target.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 39cc27ea9e650cd188f1158951e9e526
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Tests.meta
+++ b/TestUnity/Assets/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 339b76e89af5bfc7daf91f4a9cd5b357
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Tests/Editor.meta
+++ b/TestUnity/Assets/Tests/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a3e5e52362f1a1ef386ffd6074a61c71
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Tests/Editor/GameTests.cs
+++ b/TestUnity/Assets/Tests/Editor/GameTests.cs
@@ -1,0 +1,59 @@
+using NUnit.Framework;
+using UnityEditor.SceneManagement;
+using UnityEngine;
+
+public class GameTests
+{
+    [Test]
+    public void GameSceneContainsManager()
+    {
+        var scene = EditorSceneManager.OpenScene("Assets/Scenes/GameScene.unity");
+        var gm = Object.FindObjectOfType<GameManager>();
+        Assert.IsNotNull(gm);
+    }
+
+    [Test]
+    public void SetupArenaCreatesFourWalls()
+    {
+        var go = new GameObject();
+        var gm = go.AddComponent<GameManager>();
+        gm.SetupArena();
+        Assert.AreEqual(4, gm.arenaRoot.transform.childCount);
+        Object.DestroyImmediate(go);
+    }
+
+    [Test]
+    public void SpawnBallCreatesBallWithComponents()
+    {
+        var go = new GameObject();
+        var gm = go.AddComponent<GameManager>();
+        gm.SpawnBall();
+        Assert.IsNotNull(gm.ball.GetComponent<Rigidbody2D>());
+        Assert.IsNotNull(gm.ball.GetComponent<CircleCollider2D>());
+        Object.DestroyImmediate(gm.ball);
+        Object.DestroyImmediate(go);
+    }
+
+    [Test]
+    public void SpawnTargetsCreatesSpecifiedCount()
+    {
+        var go = new GameObject();
+        var gm = go.AddComponent<GameManager>();
+        gm.SpawnTargets(3);
+        Assert.AreEqual(3, gm.targets.Count);
+        foreach (var t in gm.targets) Object.DestroyImmediate(t);
+        Object.DestroyImmediate(go);
+    }
+
+    [Test]
+    public void TargetDestroyedIncrementsScore()
+    {
+        var go = new GameObject();
+        var gm = go.AddComponent<GameManager>();
+        var target = new GameObject();
+        gm.targets.Add(target);
+        gm.TargetDestroyed(target);
+        Assert.AreEqual(1, gm.score);
+        Object.DestroyImmediate(go);
+    }
+}

--- a/TestUnity/Assets/Tests/Editor/GameTests.cs.meta
+++ b/TestUnity/Assets/Tests/Editor/GameTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d86a86ba80f6a898b91db13eb4a5733b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Tests/Editor/SampleTest.cs
+++ b/TestUnity/Assets/Tests/Editor/SampleTest.cs
@@ -1,0 +1,13 @@
+using NUnit.Framework;
+
+/// <summary>
+/// サンプル用の単純な EditMode テスト
+/// </summary>
+public class SampleTest
+{
+    [Test]
+    public void Passes()
+    {
+        Assert.IsTrue(true);
+    }
+}

--- a/TestUnity/Assets/Tests/Editor/SampleTest.cs.meta
+++ b/TestUnity/Assets/Tests/Editor/SampleTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3e1bf6129314c348a81d077063e8e462
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Tests/PlayMode.meta
+++ b/TestUnity/Assets/Tests/PlayMode.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 829229135af886fc2b7a553b9e3c098c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Tests/PlayMode/GamePlayTests.cs
+++ b/TestUnity/Assets/Tests/PlayMode/GamePlayTests.cs
@@ -1,0 +1,80 @@
+using System.Collections;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+using UnityEngine.SceneManagement;
+
+public class GamePlayTests
+{
+    [UnitySetUp]
+    public IEnumerator LoadScene()
+    {
+        BallController.freeze = true;
+        SceneManager.LoadScene("GameScene", LoadSceneMode.Single);
+        yield return null; // wait one frame for scene load
+        yield return null; // extra frame to ensure Start has run
+        var ball = Object.FindObjectOfType<BallController>();
+        if (ball != null)
+            ball.GetComponent<Rigidbody2D>().velocity = Vector2.zero;
+    }
+
+    [UnityTearDown]
+    public IEnumerator TearDown()
+    {
+        BallController.freeze = false;
+        yield return null;
+    }
+
+    [UnityTest]
+    public IEnumerator BallExistsAtStart()
+    {
+        yield return null;
+        Assert.IsNotNull(Object.FindObjectOfType<BallController>());
+    }
+
+    [UnityTest]
+    public IEnumerator TargetsSpawnedAtStart()
+    {
+        yield return null;
+        var gm = Object.FindObjectOfType<GameManager>();
+        Assert.AreEqual(gm.targetCount, gm.targets.Count);
+    }
+
+    [UnityTest]
+    public IEnumerator DestroyTargetIncrementsScore()
+    {
+        var gm = Object.FindObjectOfType<GameManager>();
+        var target = gm.targets[0];
+        gm.TargetDestroyed(target);
+        Object.Destroy(target);
+        yield return null;
+        Assert.AreEqual(gm.targetCount - 1, gm.targets.Count);
+        Assert.AreEqual(1, gm.score);
+    }
+
+    [UnityTest]
+    public IEnumerator RotateArenaChangesRotation()
+    {
+        var gm = Object.FindObjectOfType<GameManager>();
+        var arena = gm.arenaRoot.GetComponent<ArenaController>();
+        float before = gm.arenaRoot.transform.rotation.eulerAngles.z;
+        arena.testInputOverride = 1f;
+        yield return new WaitForSeconds(0.1f);
+        arena.testInputOverride = 0f;
+        float after = gm.arenaRoot.transform.rotation.eulerAngles.z;
+        Assert.AreNotEqual(before, after);
+    }
+
+    [UnityTest]
+    public IEnumerator GameClearsWhenAllTargetsDestroyed()
+    {
+        var gm = Object.FindObjectOfType<GameManager>();
+        foreach (var t in new System.Collections.Generic.List<GameObject>(gm.targets))
+        {
+            gm.TargetDestroyed(t);
+            Object.Destroy(t);
+        }
+        yield return null;
+        Assert.AreEqual(GameManager.GameState.Cleared, gm.state);
+    }
+}

--- a/TestUnity/Assets/Tests/PlayMode/GamePlayTests.cs.meta
+++ b/TestUnity/Assets/Tests/PlayMode/GamePlayTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ab86be865a7d573ee86910dfccd80c3b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Packages/packages-lock.json
+++ b/TestUnity/Packages/packages-lock.json
@@ -1,5 +1,23 @@
 {
   "dependencies": {
+    "com.unity.ext.nunit": {
+      "version": "1.0.6",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.test-framework": {
+      "version": "1.1.33",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.ext.nunit": "1.0.6",
+        "com.unity.modules.imgui": "1.0.0",
+        "com.unity.modules.jsonserialize": "1.0.0"
+      },
+      "url": "https://packages.unity.com"
+    },
     "com.unity.modules.ai": {
       "version": "1.0.0",
       "depth": 0,


### PR DESCRIPTION
## Summary
- add main GameManager and arena/ball/target scripts
- auto-generate GameScene via editor script
- implement edit & play mode tests for the scene

## Testing
- `unity-editor -batchmode -nographics -projectPath TestUnity -runTests -testResults $(pwd)/edit.xml -testPlatform editmode -logFile edit.log`
- `unity-editor -batchmode -nographics -projectPath TestUnity -runTests -testResults $(pwd)/play.xml -testPlatform playmode -logFile play.log`


------
https://chatgpt.com/codex/tasks/task_e_68415f61135c8328aae835b547dc4040