### PR TITLE
Implement basic bouncing ball puzzle game

### DIFF
--- a/TestUnity/Assets/Editor/BatchBoot.cs.meta
+++ b/TestUnity/Assets/Editor/BatchBoot.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4d80c9cbe6a6e2d238d03835d7d8fc99
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Editor/CompileFailExit.cs.meta
+++ b/TestUnity/Assets/Editor/CompileFailExit.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 83ce945c5e39a6b9e9e7ac0df95ab853
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Editor/GenerateUnityTests.cs.meta
+++ b/TestUnity/Assets/Editor/GenerateUnityTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a37a92fb18ef31073904ea3f424a16b9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Editor/LogSplitter.cs.meta
+++ b/TestUnity/Assets/Editor/LogSplitter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 500d389624ccb86889ea0a70c8a66719
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Scripts/ArenaController.cs
+++ b/TestUnity/Assets/Scripts/ArenaController.cs
@@ -1,0 +1,18 @@
+using UnityEngine;
+
+public class ArenaController : MonoBehaviour
+{
+    public float rotationSpeed = 90f; // degrees per second
+
+    void Update()
+    {
+        float h = Input.GetAxis("Horizontal");
+        if (Mathf.Abs(h) > 0f)
+            Rotate(h * rotationSpeed * Time.deltaTime);
+    }
+
+    public void Rotate(float degrees)
+    {
+        transform.Rotate(0f, 0f, degrees, Space.World);
+    }
+}

--- a/TestUnity/Assets/Scripts/ArenaController.cs.meta
+++ b/TestUnity/Assets/Scripts/ArenaController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ddaefa144952c4d99bf417e6a06f8549
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Scripts/BulletController.cs
+++ b/TestUnity/Assets/Scripts/BulletController.cs
@@ -1,0 +1,31 @@
+using UnityEngine;
+
+[RequireComponent(typeof(Rigidbody))]
+public class BulletController : MonoBehaviour
+{
+    public float speed = 5f;
+    private Rigidbody rb;
+
+    void Start()
+    {
+        rb = GetComponent<Rigidbody>();
+        rb.useGravity = false;
+        rb.velocity = transform.forward.normalized * speed;
+    }
+
+    void FixedUpdate()
+    {
+        rb.velocity = rb.velocity.normalized * speed;
+    }
+
+    void OnCollisionEnter(Collision collision)
+    {
+        Vector3 normal = collision.GetContact(0).normal;
+        rb.velocity = ReflectionUtility.Reflect(rb.velocity.normalized, normal) * speed;
+
+        if (collision.gameObject.CompareTag("Target"))
+        {
+            FindObjectOfType<GameManager>()?.HitTarget(collision.gameObject);
+        }
+    }
+}

--- a/TestUnity/Assets/Scripts/BulletController.cs.meta
+++ b/TestUnity/Assets/Scripts/BulletController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e5f1f9aac1fe30652aa6fe2b3923451e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Scripts/GameManager.cs
+++ b/TestUnity/Assets/Scripts/GameManager.cs
@@ -1,0 +1,134 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+public class GameManager : MonoBehaviour
+{
+    public float timeLimit = 30f;
+    public int score = 0;
+    public float elapsed = 0f;
+
+    public GameObject bulletPrefab;
+    public GameObject targetPrefab;
+
+    private GameObject bulletInstance;
+    private List<Target> targets = new List<Target>();
+    private ArenaController arena;
+
+    void Start()
+    {
+        arena = GetComponent<ArenaController>();
+        if (arena == null)
+        {
+            arena = gameObject.AddComponent<ArenaController>();
+        }
+        SetupArena();
+        SpawnBullet();
+        SpawnTargets();
+    }
+
+    void Update()
+    {
+        elapsed += Time.deltaTime;
+        if (elapsed >= timeLimit)
+        {
+            EndGame(false);
+        }
+        if (targets.Count == 0 && elapsed < timeLimit)
+        {
+            EndGame(true);
+        }
+    }
+
+    public void TargetHit(Target target)
+    {
+        score++;
+        targets.Remove(target);
+    }
+
+    public void HitTarget(GameObject targetGo)
+    {
+        var t = targetGo.GetComponent<Target>();
+        if (t != null)
+        {
+            TargetHit(t);
+        }
+    }
+
+    void EndGame(bool cleared)
+    {
+        Debug.Log($"Game Over {(cleared ? "CLEAR" : "TIME UP")}, Score:{score}, Time:{elapsed:F2}");
+        Destroy(bulletInstance);
+        enabled = false;
+    }
+
+    void SetupArena()
+    {
+        // create child object for arena walls rotated 45 degrees
+        transform.rotation = Quaternion.Euler(0f, 0f, 45f);
+        float size = 10f;
+        float thickness = 0.5f;
+        CreateWall(new Vector3(-size/2, 0f, 0f), new Vector3(thickness, 1f, size));
+        CreateWall(new Vector3(size/2, 0f, 0f), new Vector3(thickness, 1f, size));
+        CreateWall(new Vector3(0f, 0f, -size/2), new Vector3(size, 1f, thickness));
+        CreateWall(new Vector3(0f, 0f, size/2), new Vector3(size, 1f, thickness));
+    }
+
+    void CreateWall(Vector3 pos, Vector3 scale)
+    {
+        GameObject wall = GameObject.CreatePrimitive(PrimitiveType.Cube);
+        wall.name = "Wall";
+        wall.tag = "Wall";
+        wall.transform.SetParent(transform, false);
+        wall.transform.localPosition = pos;
+        wall.transform.localScale = scale;
+        var collider = wall.GetComponent<BoxCollider>();
+        collider.material = new PhysicMaterial { bounciness = 1f, bounceCombine = PhysicMaterialCombine.Maximum, frictionCombine = PhysicMaterialCombine.Minimum };
+    }
+
+    void SpawnBullet()
+    {
+        if (bulletPrefab == null)
+        {
+            bulletInstance = GameObject.CreatePrimitive(PrimitiveType.Sphere);
+            bulletInstance.name = "Bullet";
+            bulletInstance.transform.position = Vector3.zero;
+            bulletInstance.AddComponent<Rigidbody>();
+            bulletInstance.AddComponent<BulletController>();
+        }
+        else
+        {
+            bulletInstance = Instantiate(bulletPrefab, Vector3.zero, Quaternion.identity);
+        }
+    }
+
+    void SpawnTargets()
+    {
+        Vector3[] positions = new Vector3[]
+        {
+            new Vector3(3,0,0), new Vector3(-3,0,0), new Vector3(0,0,3), new Vector3(0,0,-3)
+        };
+        foreach (var pos in positions)
+        {
+            GameObject go;
+            if (targetPrefab == null)
+            {
+                go = GameObject.CreatePrimitive(PrimitiveType.Sphere);
+                go.transform.localScale = Vector3.one * 0.5f;
+                var renderer = go.GetComponent<Renderer>();
+                if (renderer != null) renderer.material.color = new Color(1f,0.5f,0f);
+                go.AddComponent<Rigidbody>().isKinematic = true;
+                go.AddComponent<Target>();
+            }
+            else
+            {
+                go = Instantiate(targetPrefab, pos, Quaternion.identity);
+            }
+            go.name = "Target";
+            go.tag = "Target";
+            go.transform.position = pos;
+            targets.Add(go.GetComponent<Target>());
+        }
+    }
+
+    public int TargetCount => targets.Count;
+}

--- a/TestUnity/Assets/Scripts/GameManager.cs.meta
+++ b/TestUnity/Assets/Scripts/GameManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 804a363b776c15af5af1423387374a37
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Scripts/GameManagerSpawner.cs
+++ b/TestUnity/Assets/Scripts/GameManagerSpawner.cs
@@ -1,0 +1,19 @@
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+public static class GameManagerSpawner
+{
+    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
+    static void Init()
+    {
+        SceneManager.sceneLoaded += OnSceneLoaded;
+    }
+
+    static void OnSceneLoaded(Scene scene, LoadSceneMode mode)
+    {
+        if (Object.FindObjectOfType<GameManager>() == null)
+        {
+            new GameObject("GameManager", typeof(GameManager));
+        }
+    }
+}

--- a/TestUnity/Assets/Scripts/GameManagerSpawner.cs.meta
+++ b/TestUnity/Assets/Scripts/GameManagerSpawner.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0ead94dd04ddf59a9b2219ab0e9befae
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Scripts/ReflectionUtility.cs
+++ b/TestUnity/Assets/Scripts/ReflectionUtility.cs
@@ -1,0 +1,9 @@
+using UnityEngine;
+
+public static class ReflectionUtility
+{
+    public static Vector3 Reflect(Vector3 direction, Vector3 normal)
+    {
+        return direction - 2f * Vector3.Dot(direction, normal) * normal;
+    }
+}

--- a/TestUnity/Assets/Scripts/ReflectionUtility.cs.meta
+++ b/TestUnity/Assets/Scripts/ReflectionUtility.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 580e3f97627811e27bae0ad1a916e820
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Scripts/Target.cs
+++ b/TestUnity/Assets/Scripts/Target.cs
@@ -1,0 +1,22 @@
+using UnityEngine;
+
+public class Target : MonoBehaviour
+{
+    public void Hit()
+    {
+        var gm = FindObjectOfType<GameManager>();
+        if (gm != null)
+        {
+            gm.TargetHit(this);
+        }
+        Destroy(gameObject);
+    }
+
+    void OnCollisionEnter(Collision collision)
+    {
+        if (collision.gameObject.GetComponent<BulletController>() != null)
+        {
+            Hit();
+        }
+    }
+}

--- a/TestUnity/Assets/Scripts/Target.cs.meta
+++ b/TestUnity/Assets/Scripts/Target.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 68e5f94e48dd51643a47cfc57dc4f0d2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Tests.meta
+++ b/TestUnity/Assets/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bc30696eafc95fa3fae3e4a7c59c47c2
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Tests/Editor.meta
+++ b/TestUnity/Assets/Tests/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 11e9f2e897d715072953d557530aebbb
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Tests/Editor/GameTestsEdit.cs
+++ b/TestUnity/Assets/Tests/Editor/GameTestsEdit.cs
@@ -1,0 +1,53 @@
+using NUnit.Framework;
+using UnityEngine;
+
+public class GameTestsEdit
+{
+    [Test]
+    public void ReflectHorizontal()
+    {
+        Vector3 dir = new Vector3(1, 0, 0);
+        Vector3 normal = Vector3.left;
+        Vector3 reflected = ReflectionUtility.Reflect(dir, normal);
+        Assert.AreEqual(new Vector3(-1, 0, 0), reflected);
+    }
+
+    [Test]
+    public void ReflectVertical()
+    {
+        Vector3 dir = new Vector3(0, 1, 0);
+        Vector3 normal = Vector3.down;
+        Vector3 reflected = ReflectionUtility.Reflect(dir, normal);
+        Assert.AreEqual(new Vector3(0, -1, 0), reflected);
+    }
+
+    [Test]
+    public void ReflectDiagonal()
+    {
+        Vector3 dir = (new Vector3(1, -1, 0)).normalized;
+        Vector3 normal = Vector3.up;
+        Vector3 expected = (new Vector3(1, 1, 0)).normalized;
+        Vector3 reflected = ReflectionUtility.Reflect(dir, normal);
+        Assert.AreEqual(0f, Vector3.Angle(expected, reflected), 0.0001f);
+    }
+
+    [Test]
+    public void ArenaRotates()
+    {
+        GameObject go = new GameObject();
+        var arena = go.AddComponent<ArenaController>();
+        arena.Rotate(45f);
+        Assert.AreEqual(45f, go.transform.eulerAngles.z, 0.1f);
+        Object.DestroyImmediate(go);
+    }
+
+    [Test]
+    public void ScoreIncrements()
+    {
+        GameObject gmObj = new GameObject();
+        var gm = gmObj.AddComponent<GameManager>();
+        gm.TargetHit(null);
+        Assert.AreEqual(1, gm.score);
+        Object.DestroyImmediate(gmObj);
+    }
+}

--- a/TestUnity/Assets/Tests/Editor/GameTestsEdit.cs.meta
+++ b/TestUnity/Assets/Tests/Editor/GameTestsEdit.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e9c4a73388e4b6bdaa66b846857f5b33
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Tests/Editor/SampleTest.cs
+++ b/TestUnity/Assets/Tests/Editor/SampleTest.cs
@@ -1,0 +1,13 @@
+using NUnit.Framework;
+
+/// <summary>
+/// サンプル用の単純な EditMode テスト
+/// </summary>
+public class SampleTest
+{
+    [Test]
+    public void Passes()
+    {
+        Assert.IsTrue(true);
+    }
+}

--- a/TestUnity/Assets/Tests/Editor/SampleTest.cs.meta
+++ b/TestUnity/Assets/Tests/Editor/SampleTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 994073ec813e32a6baba70b861dd4651
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Tests/PlayMode.meta
+++ b/TestUnity/Assets/Tests/PlayMode.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c035a42d3c854d355a8d75c608de4c0f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Tests/PlayMode/GameTestsPlay.cs
+++ b/TestUnity/Assets/Tests/PlayMode/GameTestsPlay.cs
@@ -1,0 +1,80 @@
+using System.Collections;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using UnityEngine.TestTools;
+
+public class GameTestsPlay
+{
+    private const string SceneName = "ManagerScene";
+
+    [UnityTest]
+    public IEnumerator ObjectsSpawned()
+    {
+        SceneManager.LoadScene(SceneName);
+        yield return null;
+        yield return null;
+        yield return new WaitForSeconds(0.1f);
+        Assert.IsNotNull(Object.FindObjectOfType<GameManager>());
+        Assert.IsNotNull(Object.FindObjectOfType<BulletController>());
+        Assert.Greater(Object.FindObjectsOfType<Target>().Length, 0);
+    }
+
+    [UnityTest]
+    public IEnumerator BulletMoves()
+    {
+        SceneManager.LoadScene(SceneName);
+        yield return null;
+        yield return null;
+        yield return new WaitForSeconds(0.1f);
+        var bullet = Object.FindObjectOfType<BulletController>();
+        Vector3 start = bullet.transform.position;
+        yield return new WaitForSeconds(0.5f);
+        Vector3 end = bullet.transform.position;
+        Assert.Greater(Vector3.Distance(start, end), 0.1f);
+    }
+
+    [UnityTest]
+    public IEnumerator TargetDestroyedOnHit()
+    {
+        SceneManager.LoadScene(SceneName);
+        yield return null;
+        yield return null;
+        yield return new WaitForSeconds(0.1f);
+        var gm = Object.FindObjectOfType<GameManager>();
+        var target = Object.FindObjectOfType<Target>();
+        int initial = gm.score;
+        target.Hit();
+        yield return null;
+        Assert.AreEqual(initial + 1, gm.score);
+    }
+
+    [UnityTest]
+    public IEnumerator TimeUpEndsGame()
+    {
+        SceneManager.LoadScene(SceneName);
+        yield return null;
+        yield return null;
+        yield return new WaitForSeconds(0.1f);
+        var gm = Object.FindObjectOfType<GameManager>();
+        gm.timeLimit = 0.5f;
+        yield return new WaitForSeconds(1f);
+        Assert.IsFalse(gm.enabled);
+    }
+
+    [UnityTest]
+    public IEnumerator ClearEndsGame()
+    {
+        SceneManager.LoadScene(SceneName);
+        yield return null;
+        yield return null;
+        yield return new WaitForSeconds(0.1f);
+        var gm = Object.FindObjectOfType<GameManager>();
+        foreach (var t in Object.FindObjectsOfType<Target>())
+        {
+            t.Hit();
+        }
+        yield return null;
+        Assert.IsFalse(gm.enabled);
+    }
+}

--- a/TestUnity/Assets/Tests/PlayMode/GameTestsPlay.cs.meta
+++ b/TestUnity/Assets/Tests/PlayMode/GameTestsPlay.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7a21690763e45718d8a333356857c448
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Packages/packages-lock.json
+++ b/TestUnity/Packages/packages-lock.json
@@ -1,5 +1,23 @@
 {
   "dependencies": {
+    "com.unity.ext.nunit": {
+      "version": "1.0.6",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.test-framework": {
+      "version": "1.1.33",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.ext.nunit": "1.0.6",
+        "com.unity.modules.imgui": "1.0.0",
+        "com.unity.modules.jsonserialize": "1.0.0"
+      },
+      "url": "https://packages.unity.com"
+    },
     "com.unity.modules.ai": {
       "version": "1.0.0",
       "depth": 0,

--- a/TestUnity/ProjectSettings/TagManager.asset
+++ b/TestUnity/ProjectSettings/TagManager.asset
@@ -3,7 +3,9 @@
 --- !u!78 &1
 TagManager:
   serializedVersion: 2
-  tags: []
+  tags:
+  - Wall
+  - Target
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
## Summary
- implement GameManager and supporting scripts to spawn arena, bullet and targets
- add reflection helper and movement scripts
- spawn GameManager per scene load
- define `Wall` and `Target` tags
- create EditMode and PlayMode tests covering reflection and game flow

## Testing
- `unity-editor -batchmode -nographics -projectPath TestUnity -runTests -testPlatform editmode -testResults $(pwd)/editmode-results.xml -forceBatchBoot`
- `unity-editor -batchmode -nographics -projectPath TestUnity -runTests -testPlatform playmode -testResults $(pwd)/playmode-results.xml -forceBatchBoot`

------
https://chatgpt.com/codex/tasks/task_e_6841660f99ec8328af8bfb13e883f000