### PR TITLE
Implement simple bouncing puzzle game with tests

### DIFF
--- a/TestUnity/Assets/Editor/BatchBoot.cs.meta
+++ b/TestUnity/Assets/Editor/BatchBoot.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3dd9690f2f47e8f7fa096b230e825845
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Editor/CompileFailExit.cs.meta
+++ b/TestUnity/Assets/Editor/CompileFailExit.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6af59b017a09c9c13b8492a9ef1b697e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Editor/GenerateUnityTests.cs.meta
+++ b/TestUnity/Assets/Editor/GenerateUnityTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5c6880d3b6039e5c5b293551068c8174
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Editor/LogSplitter.cs.meta
+++ b/TestUnity/Assets/Editor/LogSplitter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8e05f5e302559b2b8b9b0fb3eed2a2ab
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Scripts/BallController.cs
+++ b/TestUnity/Assets/Scripts/BallController.cs
@@ -1,0 +1,26 @@
+using UnityEngine;
+
+[RequireComponent(typeof(Rigidbody2D))]
+public class BallController : MonoBehaviour
+{
+    public float speed = 5f;
+    Rigidbody2D rb;
+
+    void Awake()
+    {
+        rb = GetComponent<Rigidbody2D>();
+        rb.gravityScale = 0f;
+        rb.sharedMaterial = new PhysicsMaterial2D { bounciness = 1f, friction = 0f };
+        rb.collisionDetectionMode = CollisionDetectionMode2D.Continuous;
+    }
+
+    void Start()
+    {
+        rb.velocity = Vector2.right * speed;
+    }
+
+    void FixedUpdate()
+    {
+        rb.velocity = rb.velocity.normalized * speed;
+    }
+}

--- a/TestUnity/Assets/Scripts/BallController.cs.meta
+++ b/TestUnity/Assets/Scripts/BallController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2a3fc6fe904de12008c5b103e470a61f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Scripts/GameManager.cs
+++ b/TestUnity/Assets/Scripts/GameManager.cs
@@ -1,0 +1,130 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+public class GameManager : MonoBehaviour
+{
+    public int targetCount = 3;
+    public float playTime = 30f;
+    public float wallSize = 8f;
+    public float wallRotationSpeed = 45f;
+
+    [HideInInspector] public Transform wallsParent;
+    [HideInInspector] public BallController ball;
+    [HideInInspector] public List<Target> targets = new List<Target>();
+
+    public enum GameState { Playing, Clear, TimeUp }
+    public GameState State { get; private set; }
+    public int Score { get; private set; }
+    public float ElapsedTime { get; private set; }
+
+    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
+    static void InitOnLoad()
+    {
+        if (FindObjectOfType<GameManager>() == null)
+        {
+            new GameObject("GameManager").AddComponent<GameManager>();
+        }
+    }
+
+    void Start()
+    {
+        Initialize();
+    }
+
+    public void Initialize()
+    {
+        SetupField();
+        SpawnBall();
+        SpawnTargets();
+        State = GameState.Playing;
+    }
+
+    void Update()
+    {
+        if (State != GameState.Playing) return;
+
+        ElapsedTime += Time.deltaTime;
+        if (ElapsedTime >= playTime)
+        {
+            EndGame(GameState.TimeUp);
+        }
+
+        float axis = Input.GetAxisRaw("Horizontal");
+        if (Mathf.Abs(axis) > 0.01f)
+        {
+            RotateWalls(-axis * wallRotationSpeed * Time.deltaTime);
+        }
+
+        if (targets.Count == 0)
+        {
+            EndGame(GameState.Clear);
+        }
+    }
+
+    public void RotateWalls(float angle)
+    {
+        if (wallsParent != null)
+            wallsParent.Rotate(Vector3.forward, angle);
+    }
+
+    public void EndGame(GameState result)
+    {
+        State = result;
+        Debug.Log($"Game ended: {result} score {Score}");
+    }
+
+    void SetupField()
+    {
+        wallsParent = new GameObject("Walls").transform;
+        float half = wallSize / 2f;
+        CreateWall(new Vector2(0, half), new Vector2(wallSize, 0.5f));
+        CreateWall(new Vector2(0, -half), new Vector2(wallSize, 0.5f));
+        CreateWall(new Vector2(-half, 0), new Vector2(0.5f, wallSize));
+        CreateWall(new Vector2(half, 0), new Vector2(0.5f, wallSize));
+        wallsParent.rotation = Quaternion.Euler(0, 0, 45f);
+    }
+
+    void CreateWall(Vector2 pos, Vector2 size)
+    {
+        GameObject wall = new GameObject("Wall");
+        wall.transform.parent = wallsParent;
+        wall.transform.position = pos;
+        BoxCollider2D col = wall.AddComponent<BoxCollider2D>();
+        col.size = size;
+        var rb = wall.AddComponent<Rigidbody2D>();
+        rb.bodyType = RigidbodyType2D.Static;
+        rb.sharedMaterial = new PhysicsMaterial2D { bounciness = 1f, friction = 0f };
+    }
+
+    void SpawnBall()
+    {
+        GameObject go = new GameObject("Ball");
+        ball = go.AddComponent<BallController>();
+        go.AddComponent<CircleCollider2D>();
+        go.transform.position = Vector3.zero;
+    }
+
+    void SpawnTargets()
+    {
+        for (int i = 0; i < targetCount; i++)
+        {
+            GameObject go = new GameObject($"Target{i}");
+            go.transform.position = Random.insideUnitCircle * (wallSize * 0.3f);
+            var t = go.AddComponent<Target>();
+            go.AddComponent<CircleCollider2D>().isTrigger = true;
+            t.manager = this;
+            targets.Add(t);
+        }
+    }
+
+    public void TargetHit(Target t)
+    {
+        if (!targets.Contains(t)) return;
+        targets.Remove(t);
+        if (Application.isPlaying)
+            Destroy(t.gameObject);
+        else
+            DestroyImmediate(t.gameObject);
+        Score++;
+    }
+}

--- a/TestUnity/Assets/Scripts/GameManager.cs.meta
+++ b/TestUnity/Assets/Scripts/GameManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 22b03197596295d82a0984762bbb9b6c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Scripts/Target.cs
+++ b/TestUnity/Assets/Scripts/Target.cs
@@ -1,0 +1,14 @@
+using UnityEngine;
+
+public class Target : MonoBehaviour
+{
+    [HideInInspector] public GameManager manager;
+
+    void OnTriggerEnter2D(Collider2D other)
+    {
+        if (other.GetComponent<BallController>() != null)
+        {
+            manager.TargetHit(this);
+        }
+    }
+}

--- a/TestUnity/Assets/Scripts/Target.cs.meta
+++ b/TestUnity/Assets/Scripts/Target.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c52f21725a51b3360a253d043a51cbb4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Tests.meta
+++ b/TestUnity/Assets/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 25a969a7803f6c3bfabd71ab59a934a0
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Tests/Editor.meta
+++ b/TestUnity/Assets/Tests/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6f930087d80be5f0f99115293f3ef7ed
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Tests/Editor/GameManagerEditTests.cs
+++ b/TestUnity/Assets/Tests/Editor/GameManagerEditTests.cs
@@ -1,0 +1,61 @@
+using NUnit.Framework;
+using UnityEngine;
+
+public class GameManagerEditTests
+{
+    GameManager gm;
+
+    [SetUp]
+    public void Setup()
+    {
+        var go = new GameObject();
+        gm = go.AddComponent<GameManager>();
+        gm.targetCount = 2;
+        gm.Initialize();
+    }
+
+    [TearDown]
+    public void Teardown()
+    {
+        Object.DestroyImmediate(gm.gameObject);
+        if (gm.wallsParent) Object.DestroyImmediate(gm.wallsParent.gameObject);
+        foreach (var t in gm.targets)
+            if (t) Object.DestroyImmediate(t.gameObject);
+    }
+
+    [Test]
+    public void WallsCreatedAndRotated()
+    {
+        Assert.AreEqual(4, gm.wallsParent.childCount);
+        Assert.AreEqual(45f, gm.wallsParent.eulerAngles.z, 0.1f);
+    }
+
+    [Test]
+    public void BallCreated()
+    {
+        Assert.IsNotNull(gm.ball);
+        Assert.IsNotNull(gm.ball.GetComponent<Rigidbody2D>());
+    }
+
+    [Test]
+    public void TargetsSpawned()
+    {
+        Assert.AreEqual(2, gm.targets.Count);
+    }
+
+    [Test]
+    public void TargetHitIncrementsScore()
+    {
+        var t = gm.targets[0];
+        gm.TargetHit(t);
+        Assert.AreEqual(1, gm.Score);
+        Assert.AreEqual(1, gm.targets.Count);
+    }
+
+    [Test]
+    public void EndGameChangesState()
+    {
+        gm.EndGame(GameManager.GameState.Clear);
+        Assert.AreNotEqual(GameManager.GameState.Playing, gm.State);
+    }
+}

--- a/TestUnity/Assets/Tests/Editor/GameManagerEditTests.cs.meta
+++ b/TestUnity/Assets/Tests/Editor/GameManagerEditTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a9e8c8bf37a31a04592293a9cfd23813
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Tests/Editor/SampleTest.cs
+++ b/TestUnity/Assets/Tests/Editor/SampleTest.cs
@@ -1,0 +1,13 @@
+using NUnit.Framework;
+
+/// <summary>
+/// サンプル用の単純な EditMode テスト
+/// </summary>
+public class SampleTest
+{
+    [Test]
+    public void Passes()
+    {
+        Assert.IsTrue(true);
+    }
+}

--- a/TestUnity/Assets/Tests/Editor/SampleTest.cs.meta
+++ b/TestUnity/Assets/Tests/Editor/SampleTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0ff87be60a0bd78448cea53148509a1c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Tests/PlayMode.meta
+++ b/TestUnity/Assets/Tests/PlayMode.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 80d84eea5084fd7e1a7f5a4b4c0c16c9
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Assets/Tests/PlayMode/GameManagerPlayTests.cs
+++ b/TestUnity/Assets/Tests/PlayMode/GameManagerPlayTests.cs
@@ -1,0 +1,99 @@
+using NUnit.Framework;
+using System.Collections;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+public class GameManagerPlayTests
+{
+    GameManager gm;
+    Target dummy;
+
+    [UnitySetUp]
+    public IEnumerator Setup()
+    {
+        var go = new GameObject();
+        gm = go.AddComponent<GameManager>();
+        gm.targetCount = 0;
+        gm.playTime = 0.2f;
+        gm.wallSize = 4f;
+        gm.Initialize();
+        var obj = new GameObject();
+        dummy = obj.AddComponent<Target>();
+        obj.AddComponent<CircleCollider2D>().isTrigger = true;
+        dummy.manager = gm;
+        dummy.transform.position = Vector3.left * 10f;
+        gm.targets.Add(dummy);
+        yield return null; // wait one frame
+    }
+
+    [UnityTearDown]
+    public IEnumerator Teardown()
+    {
+        Object.Destroy(gm.wallsParent.gameObject);
+        Object.Destroy(gm.gameObject);
+        foreach (var t in gm.targets)
+            Object.Destroy(t.gameObject);
+        if (dummy) Object.Destroy(dummy.gameObject);
+        yield return null;
+    }
+
+    [UnityTest]
+    public IEnumerator BallMoves()
+    {
+        Vector3 start = gm.ball.transform.position;
+        yield return new WaitForSeconds(0.1f);
+        Assert.AreNotEqual(start, gm.ball.transform.position);
+    }
+
+    [UnityTest]
+    public IEnumerator ScoreIncrementsOnHit()
+    {
+        var tgtObj = new GameObject();
+        var target = tgtObj.AddComponent<Target>();
+        tgtObj.AddComponent<CircleCollider2D>().isTrigger = true;
+        target.manager = gm;
+        target.transform.position = gm.ball.transform.position + Vector3.right * 0.5f;
+        gm.targets.Add(target);
+        yield return new WaitForSeconds(0.2f);
+        Assert.AreEqual(1, gm.Score);
+    }
+
+    [UnityTest]
+    public IEnumerator ClearAfterAllTargetsDestroyed()
+    {
+        gm.targets.Remove(dummy);
+        Object.Destroy(dummy.gameObject);
+        var tgtObj = new GameObject();
+        var target = tgtObj.AddComponent<Target>();
+        tgtObj.AddComponent<CircleCollider2D>().isTrigger = true;
+        target.manager = gm;
+        gm.targets.Add(target);
+        gm.TargetHit(target);
+        yield return null;
+        Assert.AreEqual(GameManager.GameState.Clear, gm.State);
+    }
+
+    [UnityTest]
+    public IEnumerator TimeUpEndsGame()
+    {
+        gm.playTime = 0.1f;
+        var tgtObj = new GameObject();
+        var target = tgtObj.AddComponent<Target>();
+        tgtObj.AddComponent<CircleCollider2D>().isTrigger = true;
+        target.manager = gm;
+        target.transform.position = Vector3.left * 10f;
+        gm.targets.Add(target);
+        yield return new WaitForSeconds(0.15f);
+        Assert.AreEqual(GameManager.GameState.TimeUp, gm.State);
+    }
+
+    [UnityTest]
+    public IEnumerator RotateWallsAffectsDirection()
+    {
+        float before = gm.wallsParent.eulerAngles.z;
+        gm.RotateWalls(45f);
+        yield return null;
+        float after = gm.wallsParent.eulerAngles.z;
+        Assert.AreNotEqual(before, after);
+    }
+}

--- a/TestUnity/Assets/Tests/PlayMode/GameManagerPlayTests.cs.meta
+++ b/TestUnity/Assets/Tests/PlayMode/GameManagerPlayTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d829766142f65eb068f80609eea15920
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestUnity/Packages/packages-lock.json
+++ b/TestUnity/Packages/packages-lock.json
@@ -1,5 +1,23 @@
 {
   "dependencies": {
+    "com.unity.ext.nunit": {
+      "version": "1.0.6",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.test-framework": {
+      "version": "1.1.33",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.ext.nunit": "1.0.6",
+        "com.unity.modules.imgui": "1.0.0",
+        "com.unity.modules.jsonserialize": "1.0.0"
+      },
+      "url": "https://packages.unity.com"
+    },
     "com.unity.modules.ai": {
       "version": "1.0.0",
       "depth": 0,

--- a/TestUnity/ProjectSettings/EditorBuildSettings.asset
+++ b/TestUnity/ProjectSettings/EditorBuildSettings.asset
@@ -4,5 +4,29 @@
 EditorBuildSettings:
   m_ObjectHideFlags: 0
   serializedVersion: 2
-  m_Scenes: []
+  m_Scenes:
+  - enabled: 1
+    path: Assets/Scenes/GeneratedScene.unity
+    guid: 95b371128d69f4b44845a3724c9674fe
+  - enabled: 1
+    path: Assets/Scenes/ManagerScene.unity
+    guid: d57469f773787db4fab49d8e855330eb
+  - enabled: 1
+    path: Assets/InitTestScene638847744739705040.unity
+    guid: efe54ff45d328e207a8eabdced5a49ea
+  - enabled: 1
+    path: Assets/InitTestScene638847745355939380.unity
+    guid: 2221bbfa3fa07692f96d595ab13b9e90
+  - enabled: 1
+    path: Assets/InitTestScene638847745787853170.unity
+    guid: 235f562985985eb699f5fc432a75a508
+  - enabled: 1
+    path: Assets/InitTestScene638847746276958730.unity
+    guid: 310f9374b30cd16b9995e018c4845928
+  - enabled: 1
+    path: Assets/InitTestScene638847746701569140.unity
+    guid: 31a168933db960d5a85cf11fccbd7045
+  - enabled: 1
+    path: Assets/InitTestScene638847747417790250.unity
+    guid: 300217953c32c498cb3cc9dcdc3cbab1
   m_configObjects: {}

--- a/TestUnity/ProjectSettings/ProjectSettings.asset
+++ b/TestUnity/ProjectSettings/ProjectSettings.asset
@@ -78,7 +78,7 @@ PlayerSettings:
   androidFullscreenMode: 1
   defaultIsNativeResolution: 1
   macRetinaSupport: 1
-  runInBackground: 0
+  runInBackground: 1
   captureSingleScreen: 0
   muteOtherAudioSources: 0
   Prepare IOS For Recording: 0
@@ -152,13 +152,17 @@ PlayerSettings:
   useHDRDisplay: 0
   hdrBitDepth: 0
   m_ColorGamuts: 00000000
-  targetPixelDensity: 0
+  targetPixelDensity: 30
   resolutionScalingMode: 0
   resetResolutionOnWindowResize: 0
   androidSupportedAspectRatio: 1
   androidMaxAspectRatio: 2.1
   applicationIdentifier: {}
-  buildNumber: {}
+  buildNumber:
+    Standalone: 0
+    VisionOS: 0
+    iPhone: 0
+    tvOS: 0
   overrideDefaultApplicationIdentifier: 0
   AndroidBundleVersionCode: 1
   AndroidMinSdkVersion: 22
@@ -177,12 +181,12 @@ PlayerSettings:
   strictShaderVariantMatching: 0
   VertexChannelCompressionMask: 4054
   iPhoneSdkVersion: 988
-  iOSTargetOSVersionString: 
+  iOSTargetOSVersionString: 12.0
   tvOSSdkVersion: 0
   tvOSRequireExtendedGameController: 0
-  tvOSTargetOSVersionString: 
+  tvOSTargetOSVersionString: 12.0
   VisionOSSdkVersion: 0
-  VisionOSTargetOSVersionString: 
+  VisionOSTargetOSVersionString: 1.0
   uIPrerenderedIcon: 0
   uIRequiresPersistentWiFi: 0
   uIRequiresFullScreen: 1
@@ -309,7 +313,7 @@ PlayerSettings:
   locationUsageDescription: 
   microphoneUsageDescription: 
   bluetoothUsageDescription: 
-  macOSTargetOSVersion: 
+  macOSTargetOSVersion: 10.13.0
   switchNMETAOverride: 
   switchNetLibKey: 
   switchSocketMemoryPoolSize: 6144


### PR DESCRIPTION
## Summary
- add GameManager, BallController and Target scripts for core gameplay
- create edit and play mode tests covering object creation and game flow
- update project settings generated by Unity

## Testing
- `unity-editor -batchmode -nographics -projectPath TestUnity -runTests -testPlatform editmode -testResults $(pwd)/editmode-results.xml -forceBatchBoot`
- `unity-editor -batchmode -nographics -projectPath TestUnity -runTests -testPlatform playmode -testResults $(pwd)/playmode-results.xml -forceBatchBoot`

------
https://chatgpt.com/codex/tasks/task_e_684252ec02608328bf9e3098e45e8e30